### PR TITLE
Fix release test hooks for macOS sandbox tests

### DIFF
--- a/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
@@ -856,8 +856,8 @@ extension XPCMessage {
     }
 }
 
-#if DEBUG
 extension MacOSSandboxService {
+    // These hooks are used by release-mode test builds in CI.
     func testingAddSession(id: String, config: ProcessConfiguration) {
         sessions[id] = Session(processID: id, config: config, stdio: [nil, nil, nil])
     }
@@ -874,4 +874,3 @@ extension MacOSSandboxService {
         waiters[id]?.count ?? 0
     }
 }
-#endif


### PR DESCRIPTION
This pull request makes a minor change to the `MacOSSandboxService` in `MacOSSandboxService.swift`, ensuring that certain test hooks are always available, not just in debug builds. This supports release-mode test builds in CI.

Testing and build configuration:

* Removed `#if DEBUG`/`#endif` guards around test hook methods in `MacOSSandboxService`, making them accessible in all build configurations to support release-mode CI testing. [[1]](diffhunk://#diff-1772181ba2e739f998649889ce77d6f5bb09d7bd85d7c4b00ee2aa81f006cdebL859-R860) [[2]](diffhunk://#diff-1772181ba2e739f998649889ce77d6f5bb09d7bd85d7c4b00ee2aa81f006cdebL877)