### PR TITLE
fix CI test lifecycle races

### DIFF
--- a/Sources/ContainerCommands/System/SystemStop.swift
+++ b/Sources/ContainerCommands/System/SystemStop.swift
@@ -95,7 +95,11 @@ extension Application {
 
             if isRegistered {
                 log.info("stopping service", metadata: ["label": "\(fullLabel)"])
-                try? ServiceManager.deregister(fullServiceLabel: fullLabel)
+                do {
+                    try ServiceManager.deregister(fullServiceLabel: fullLabel)
+                } catch {
+                    log.warning("failed to stop service", metadata: ["label": "\(fullLabel)", "error": "\(error)"])
+                }
             }
 
             // Note: The assumption here is that we would have registered the launchd services
@@ -107,7 +111,11 @@ extension Application {
                 .map { "\(launchdDomainString)/\($0)" }
                 .forEach {
                     log.info("stopping service", metadata: ["label": "\($0)"])
-                    try? ServiceManager.deregister(fullServiceLabel: $0)
+                    do {
+                        try ServiceManager.deregister(fullServiceLabel: $0)
+                    } catch {
+                        log.warning("failed to stop service", metadata: ["label": "\($0)", "error": "\(error)"])
+                    }
                 }
         }
     }

--- a/Sources/ContainerPlugin/ServiceManager.swift
+++ b/Sources/ContainerPlugin/ServiceManager.swift
@@ -18,6 +18,9 @@ import ContainerizationError
 import Foundation
 
 public struct ServiceManager {
+    private static let bootoutPollIntervalSeconds = 0.1
+    private static let bootoutTimeoutSeconds = 5.0
+
     private struct LaunchctlCommandResult {
         let status: Int32
         let stdout: String
@@ -96,7 +99,23 @@ public struct ServiceManager {
 
     /// Deregister a service by a launchd label.
     public static func deregister(fullServiceLabel label: String) throws {
-        try runLaunchctlCommandChecked(args: ["bootout", label])
+        let result = try runLaunchctlCommand(args: ["bootout", label], captureOutput: true)
+        if result.status == 0 {
+            try waitForServiceToDisappear(fullServiceLabel: label)
+            return
+        }
+
+        let output = result.combinedOutput
+        if result.status == 3 && output.contains("No such process") {
+            return
+        }
+
+        let command = "launchctl bootout \(label)"
+        let details = output.isEmpty ? "" : ", output: \(output)"
+        throw ContainerizationError(
+            .internalError,
+            message: "command `\(command)` failed with status \(result.status)\(details)"
+        )
     }
 
     /// Restart a service by a launchd label.
@@ -183,5 +202,22 @@ public struct ServiceManager {
         default:
             throw ContainerizationError(.internalError, message: "unsupported session type \(currentSessionType)")
         }
+    }
+
+    private static func waitForServiceToDisappear(fullServiceLabel label: String) throws {
+        let launchdLabel = String(label.split(separator: "/").last ?? Substring(label))
+        let deadline = Date().addingTimeInterval(Self.bootoutTimeoutSeconds)
+
+        while Date() < deadline {
+            if try !Self.isRegistered(fullServiceLabel: launchdLabel) {
+                return
+            }
+            Thread.sleep(forTimeInterval: Self.bootoutPollIntervalSeconds)
+        }
+
+        throw ContainerizationError(
+            .timeout,
+            message: "timed out waiting for launchd to remove service `\(launchdLabel)`"
+        )
     }
 }

--- a/Sources/Helpers/MacOSGuestAgent/MacOSGuestAgent.swift
+++ b/Sources/Helpers/MacOSGuestAgent/MacOSGuestAgent.swift
@@ -275,14 +275,17 @@ final class AgentConnection: @unchecked Sendable {
 
         let terminal = frame.terminal == true
         let explicitIdentity = try GuestAgentExecIdentity.resolve(from: frame)
-        if terminal || explicitIdentity != nil {
+        let spawnedIdentity = explicitIdentity.flatMap { identity in
+            identity.requiresSpawnedSession() ? identity : nil
+        }
+        if terminal || spawnedIdentity != nil {
             let session = try SpawnedProcessSession.spawn(
                 executable: executable,
                 arguments: frame.arguments ?? [],
                 environment: frame.environment ?? [],
                 workingDirectory: frame.workingDirectory,
                 terminal: terminal,
-                identity: explicitIdentity ?? .currentProcess(),
+                identity: spawnedIdentity ?? .currentProcess(),
                 connection: self
             )
             self.session = session
@@ -592,6 +595,10 @@ struct GuestAgentExecIdentity {
 
     static func currentProcess() -> Self {
         .init(uid: geteuid(), gid: getegid(), supplementalGroups: [])
+    }
+
+    func requiresSpawnedSession(relativeTo currentIdentity: Self = .currentProcess()) -> Bool {
+        uid != currentIdentity.uid || gid != currentIdentity.gid || !supplementalGroups.isEmpty
     }
 
     static func resolve(from frame: GuestAgentFrame) throws -> Self? {
@@ -1203,7 +1210,13 @@ private final class ProcessSession: GuestAgentProcessSession, @unchecked Sendabl
             self?.flushOutputAndSendExit(process.terminationStatus)
         }
 
-        try process.run()
+        do {
+            try process.run()
+        } catch let error as CocoaError where error.code == .fileNoSuchFile {
+            throw POSIXError(.ENOENT)
+        } catch {
+            throw error
+        }
     }
 
     func writeStdin(_ data: Data) throws {

--- a/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
@@ -238,6 +238,11 @@ public actor MacOSSandboxService {
         let client: MacOSSidecarClient
     }
 
+    struct SessionWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<ExitStatus, Never>
+    }
+
     let root: URL
     private let connection: xpc_connection_t?
     let log: Logger
@@ -249,7 +254,7 @@ public actor MacOSSandboxService {
     private var workloads: [String: WorkloadRecord] = [:]
     private var workloadSessions: [String: String] = [:]
     private var externalProcessIDs: Set<String> = []
-    private var waiters: [String: [CheckedContinuation<ExitStatus, Never>]] = [:]
+    private var waiters: [String: [SessionWaiter]] = [:]
     var guestMountsPrepared = false
     var readOnlyInjectionsPrepared = false
     private var guestAgentLogCaptureProcessID: String?
@@ -2451,22 +2456,70 @@ extension MacOSSandboxService {
         guard sessions[sessionID] != nil else {
             throw ContainerizationError(.notFound, message: "session \(sessionID) not found")
         }
-        return await withCheckedContinuation { continuation in
-            addWaiter(id: sessionID, continuation: continuation)
+        try Task.checkCancellation()
+
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return await withCheckedContinuation { continuation in
+                if let status = sessions[sessionID]?.exitStatus {
+                    continuation.resume(returning: status)
+                    return
+                }
+                guard sessions[sessionID] != nil else {
+                    continuation.resume(returning: ExitStatus(exitCode: 255, exitedAt: Date()))
+                    return
+                }
+                if Task.isCancelled {
+                    continuation.resume(returning: ExitStatus(exitCode: 255, exitedAt: Date()))
+                    return
+                }
+                addWaiter(id: sessionID, waiterID: waiterID, continuation: continuation)
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: sessionID, waiterID: waiterID, reason: "wait_cancelled") }
         }
     }
 
-    private func addWaiter(id: String, continuation: CheckedContinuation<ExitStatus, Never>) {
+    private func addWaiter(id: String, waiterID: UUID, continuation: CheckedContinuation<ExitStatus, Never>) {
         var current = waiters[id] ?? []
-        current.append(continuation)
+        current.append(SessionWaiter(id: waiterID, continuation: continuation))
         waiters[id] = current
         writeContainerLog(Data(("waiter added for \(id); total=\(current.count)\n").utf8))
     }
 
     private func removeWaiters(for id: String) -> [CheckedContinuation<ExitStatus, Never>] {
-        let continuations = waiters[id] ?? []
+        let continuations = waiters[id]?.map(\.continuation) ?? []
         waiters[id] = []
         return continuations
+    }
+
+    private func removeWaiter(
+        for id: String,
+        waiterID: UUID
+    ) -> CheckedContinuation<ExitStatus, Never>? {
+        guard var current = waiters[id] else {
+            return nil
+        }
+        guard let index = current.firstIndex(where: { $0.id == waiterID }) else {
+            return nil
+        }
+
+        let continuation = current.remove(at: index).continuation
+        waiters[id] = current
+        return continuation
+    }
+
+    private func cancelWaiter(id: String, waiterID: UUID, reason: String) {
+        guard let continuation = removeWaiter(for: id, waiterID: waiterID) else {
+            return
+        }
+
+        let status = sessions[id]?.exitStatus ?? ExitStatus(exitCode: 255, exitedAt: Date())
+        writeContainerLog(
+            Data(("cancelling waiter for \(id) code=\(status.exitCode) reason=\(reason)\n").utf8)
+        )
+        continuation.resume(returning: status)
     }
 
     private func resumeWaiters(
@@ -2567,11 +2620,6 @@ extension MacOSSandboxService {
                 return value
             } catch {
                 group.cancelAll()
-                resumeWaiters(
-                    for: sessionID,
-                    fallbackStatus: ExitStatus(exitCode: 255, exitedAt: Date()),
-                    reason: "wait_timeout_or_cancelled"
-                )
                 throw error
             }
         }

--- a/Sources/Helpers/RuntimeMacOS/MacOSSidecarClient.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSidecarClient.swift
@@ -28,6 +28,7 @@ final class MacOSSidecarClient: @unchecked Sendable {
 
     private let socketPath: String
     private let log: Logger
+    private let requestTimeoutSeconds: TimeInterval
     private let stateLock = NSLock()
     private let writeLock = NSLock()
 
@@ -37,9 +38,10 @@ final class MacOSSidecarClient: @unchecked Sendable {
     private var lastControlError: Error?
     private var eventHandler: (@Sendable (MacOSSidecarEvent) -> Void)?
 
-    init(socketPath: String, log: Logger) {
+    init(socketPath: String, log: Logger, requestTimeoutSeconds: TimeInterval = 10.0) {
         self.socketPath = socketPath
         self.log = log
+        self.requestTimeoutSeconds = requestTimeoutSeconds
     }
 
     deinit {
@@ -186,7 +188,16 @@ final class MacOSSidecarClient: @unchecked Sendable {
             throw error
         }
 
-        waiter.semaphore.wait()
+        let timeoutResult = waiter.semaphore.wait(timeout: .now() + requestTimeoutSeconds)
+        if timeoutResult == .timedOut {
+            let timeoutError = ContainerizationError(
+                .timeout,
+                message: "sidecar request \(request.method.rawValue) timed out after \(requestTimeoutSeconds) seconds"
+            )
+            removePending(requestID: request.requestID)
+            handleReaderFailure(timeoutError)
+            throw timeoutError
+        }
         switch waiter.result {
         case .success(let response)?:
             try validate(response: response, expectedRequestID: request.requestID)
@@ -288,6 +299,7 @@ final class MacOSSidecarClient: @unchecked Sendable {
         stateLock.unlock()
 
         if fd >= 0 {
+            _ = Darwin.shutdown(fd, SHUT_RDWR)
             Darwin.close(fd)
         }
         if !shouldHandle && pendingToFail.isEmpty {

--- a/Sources/Services/ContainerAPIService/Client/ExecSyncRunner.swift
+++ b/Sources/Services/ContainerAPIService/Client/ExecSyncRunner.swift
@@ -17,9 +17,16 @@
 import ContainerResource
 import ContainerizationError
 import Darwin
+import Dispatch
 import Foundation
 
 enum ExecSyncRunner {
+    private static let blockingIOQueue = DispatchQueue(
+        label: "com.apple.container.exec-sync-runner.blocking-io",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
     static func run(
         timeout: Duration? = nil,
         standardInput: Data? = nil,
@@ -36,17 +43,15 @@ enum ExecSyncRunner {
         let stderrRead = stderrPipe.fileHandleForReading
         let stderrWrite = stderrPipe.fileHandleForWriting
 
-        let stdoutReader = Task<Data, Error> {
-            try stdoutRead.readToEnd() ?? Data()
-        }
-        let stderrReader = Task<Data, Error> {
-            try stderrRead.readToEnd() ?? Data()
-        }
+        let stdoutReader = Task<Data, Error> { try await readToEnd(stdoutRead) }
+        let stderrReader = Task<Data, Error> { try await readToEnd(stderrRead) }
 
         let stdinWriter = standardInput.map { input in
             Task<Void, Never> {
-                defer { try? stdinWrite?.close() }
-                try? stdinWrite?.write(contentsOf: input)
+                guard let stdinWrite else {
+                    return
+                }
+                await write(input, to: stdinWrite)
             }
         }
 
@@ -129,6 +134,45 @@ enum ExecSyncRunner {
                 .timeout,
                 message: "timed out waiting for exec process \(process.id)"
             )
+        }
+    }
+
+    private static func readToEnd(_ handle: FileHandle) async throws -> Data {
+        try await runBlockingIO {
+            defer { try? handle.close() }
+            return try handle.readToEnd() ?? Data()
+        }
+    }
+
+    private static func write(_ data: Data, to handle: FileHandle) async {
+        await runBlockingIOIgnoringErrors {
+            defer { try? handle.close() }
+            try handle.write(contentsOf: data)
+        }
+    }
+
+    private static func runBlockingIO<T: Sendable>(
+        _ operation: @escaping @Sendable () throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            blockingIOQueue.async {
+                do {
+                    continuation.resume(returning: try operation())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private static func runBlockingIOIgnoringErrors(
+        _ operation: @escaping @Sendable () throws -> Void
+    ) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            blockingIOQueue.async {
+                defer { continuation.resume() }
+                _ = try? operation()
+            }
         }
     }
 }

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -396,10 +396,13 @@ public actor ContainersService {
             try await self.lock.withLock { context in
                 var state = try await self.getContainerState(id: id, context: context)
                 if state.client == nil {
-                    try await self.registerContainerExitCallback(id: id)
-                    try await self.trackContainerExit(id: id, client: sandboxClient)
                     let sandboxSnapshot = try await sandboxClient.state()
-                    state.snapshot.status = Self.containerRuntimeStatus(from: sandboxSnapshot)
+                    let runtimeStatus = Self.containerRuntimeStatus(from: sandboxSnapshot)
+                    try await self.registerContainerExitCallback(id: id)
+                    if runtimeStatus == .running {
+                        try await self.trackContainerExit(id: id, client: sandboxClient)
+                    }
+                    state.snapshot.status = runtimeStatus
                     state.snapshot.networks = sandboxSnapshot.networks
                     state.snapshot.startedDate =
                         state.snapshot.status == .running
@@ -688,8 +691,6 @@ public actor ContainersService {
                     return StartProcessResult.exec
                 }
 
-                try await self.trackContainerExit(id: id, client: client)
-
                 let sandboxSnapshot = try await client.state()
                 return .initProcessStarted(networks: sandboxSnapshot.networks)
             }
@@ -704,15 +705,21 @@ public actor ContainersService {
         case .run(let task, let client, let isInit):
             do {
                 let result = try await task.value
-                try await self.lock.withLock { context in
+                let shouldTrackExit = try await self.lock.withLock { context -> Bool in
                     var state = try await self.getContainerState(id: id, context: context)
                     state.processStartTasks.removeValue(forKey: processID)
+                    var shouldTrackExit = false
                     if case .initProcessStarted(let networks) = result {
+                        shouldTrackExit = state.snapshot.status != .running
                         state.snapshot.status = .running
                         state.snapshot.networks = networks
                         state.snapshot.startedDate = Date()
                     }
                     await self.setContainerState(id, state, context: context)
+                    return shouldTrackExit
+                }
+                if isInit, shouldTrackExit {
+                    try await self.trackContainerExit(id: id, client: client)
                 }
             } catch {
                 try? await self.lock.withLock { context in
@@ -1230,12 +1237,11 @@ public actor ContainersService {
                 ]
             )
 
-            guard shouldTrackExit else {
-                return
-            }
-
             do {
                 try await self.registerContainerExitCallback(id: id)
+                guard shouldTrackExit else {
+                    return
+                }
                 try await self.trackContainerExit(id: id, client: client)
             } catch {
                 self.log.warning(

--- a/Sources/SocketForwarder/ConnectHandler.swift
+++ b/Sources/SocketForwarder/ConnectHandler.swift
@@ -76,14 +76,20 @@ extension ConnectHandler: RemovableChannelHandler {
 extension ConnectHandler {
     private func connectToServer(context: ChannelHandlerContext) {
         self.log?.trace("backend - connecting")
+        if let channelTracker, !channelTracker.beginPendingOperation() {
+            self.log?.trace("backend - forwarder is closing, skipping backend connect")
+            context.close(promise: nil)
+            return
+        }
 
         ClientBootstrap(group: context.eventLoop)
             .connect(to: serverAddress)
             .assumeIsolatedUnsafeUnchecked()
-            .whenComplete { result in
+            .whenComplete { [channelTracker = self.channelTracker] result in
+                defer { channelTracker?.endPendingOperation() }
                 switch result {
                 case .success(let channel):
-                    self.channelTracker?.register(channel)
+                    channelTracker?.register(channel)
                     guard context.channel.isActive else {
                         self.log?.trace("backend - frontend channel closed, closing backend connection")
                         channel.close(mode: .all, promise: nil)

--- a/Sources/SocketForwarder/SocketForwarderResult.swift
+++ b/Sources/SocketForwarder/SocketForwarderResult.swift
@@ -20,6 +20,7 @@ import NIO
 final class ForwarderChannelTracker: @unchecked Sendable {
     private let lock = NSLock()
     private var channels: [ObjectIdentifier: any Channel] = [:]
+    private var pendingOperations = 0
     private var waiters: [EventLoopPromise<Void>] = []
     private var isClosing = false
 
@@ -43,6 +44,38 @@ final class ForwarderChannelTracker: @unchecked Sendable {
         }
     }
 
+    func beginPendingOperation() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !isClosing else {
+            return false
+        }
+
+        pendingOperations += 1
+        return true
+    }
+
+    func endPendingOperation() {
+        let waitersToWake: [EventLoopPromise<Void>]
+
+        lock.lock()
+        if pendingOperations > 0 {
+            pendingOperations -= 1
+        }
+        if isClosing && channels.isEmpty && pendingOperations == 0 {
+            waitersToWake = waiters
+            waiters.removeAll()
+        } else {
+            waitersToWake = []
+        }
+        lock.unlock()
+
+        for waiter in waitersToWake {
+            waiter.succeed(())
+        }
+    }
+
     func closeAll() {
         let channelsToClose: [any Channel]
         let waitersToWake: [EventLoopPromise<Void>]
@@ -50,7 +83,7 @@ final class ForwarderChannelTracker: @unchecked Sendable {
         lock.lock()
         isClosing = true
         channelsToClose = Array(channels.values)
-        if channelsToClose.isEmpty {
+        if channelsToClose.isEmpty && pendingOperations == 0 {
             waitersToWake = waiters
             waiters.removeAll()
         } else {
@@ -70,7 +103,7 @@ final class ForwarderChannelTracker: @unchecked Sendable {
 
     func waitForDrain(on eventLoop: any EventLoop) -> EventLoopFuture<Void> {
         lock.lock()
-        if channels.isEmpty {
+        if channels.isEmpty && pendingOperations == 0 {
             lock.unlock()
             return eventLoop.makeSucceededFuture(())
         }
@@ -86,7 +119,7 @@ final class ForwarderChannelTracker: @unchecked Sendable {
 
         lock.lock()
         channels.removeValue(forKey: identifier)
-        if isClosing && channels.isEmpty {
+        if isClosing && channels.isEmpty && pendingOperations == 0 {
             waitersToWake = waiters
             waiters.removeAll()
         } else {
@@ -124,8 +157,14 @@ public struct SocketForwarderResult: Sendable {
 
     public func wait() async throws {
         try await self.channel.closeFuture.get()
+        try await waitForEventLoopQuiescence(on: self.channel.eventLoop)
         if let tracker = self.tracker {
             try await tracker.waitForDrain(on: self.channel.eventLoop).get()
         }
+        try await waitForEventLoopQuiescence(on: self.channel.eventLoop)
     }
+}
+
+private func waitForEventLoopQuiescence(on eventLoop: any EventLoop) async throws {
+    try await eventLoop.submit {}.get()
 }

--- a/Sources/SocketForwarder/UDPForwarder.swift
+++ b/Sources/SocketForwarder/UDPForwarder.swift
@@ -137,6 +137,10 @@ private final class UDPProxyFrontend: ChannelInboundHandler {
                 context.proxy.write(data: inbound.data)
             } else {
                 self.log?.trace("frontend - creating backend")
+                guard self.channelTracker.beginPendingOperation() else {
+                    self.log?.trace("frontend - forwarder is closing, skipping backend creation")
+                    return
+                }
                 let proxy = UDPProxyBackend(
                     clientAddress: inbound.remoteAddress,
                     serverAddress: self.serverAddress,
@@ -146,7 +150,7 @@ private final class UDPProxyFrontend: ChannelInboundHandler {
                 let proxyAddress = try SocketAddress(ipAddress: "0.0.0.0", port: 0)
                 let loopBoundProxy = NIOLoopBound(proxy, eventLoop: context.eventLoop)
                 let channelTracker = self.channelTracker
-                let proxyToServerFuture = DatagramBootstrap(group: context.eventLoop)
+                let proxyBindFuture = DatagramBootstrap(group: context.eventLoop)
                     .channelInitializer { [log] channel in
                         log?.trace("frontend - initializing backend")
                         return channel.eventLoop.makeCompletedFuture {
@@ -154,11 +158,16 @@ private final class UDPProxyFrontend: ChannelInboundHandler {
                         }
                     }
                     .bind(to: proxyAddress)
+                let proxyToServerFuture =
+                    proxyBindFuture
                     .map { channel in
                         channelTracker.register(channel)
                         return channel.closeFuture
                     }
                     .flatMap { $0 }
+                proxyBindFuture.whenComplete { _ in
+                    channelTracker.endPendingOperation()
+                }
                 let context = ProxyContext(proxy: proxy, closeFuture: proxyToServerFuture)
                 if let (_, evictedContext) = proxies.put(key: key, value: context) {
                     self.log?.trace("frontend - closing evicted backend")

--- a/Tests/ContainerAPIClientTests/ExecSyncTests.swift
+++ b/Tests/ContainerAPIClientTests/ExecSyncTests.swift
@@ -17,6 +17,7 @@
 import ContainerizationError
 import ContainerizationOS
 import Darwin
+import Dispatch
 import Foundation
 import Testing
 
@@ -26,6 +27,7 @@ struct ExecSyncTests {
     @Test
     func capturesStdoutStderrAndStandardInput() async throws {
         let input = Data("hello from stdin".utf8)
+        let state = CapturingProcessState()
 
         let result = try await ExecSyncRunner.run(
             standardInput: input
@@ -33,16 +35,32 @@ struct ExecSyncTests {
             let stdin = try #require(stdio[0])
             let stdout = try #require(stdio[1])
             let stderr = try #require(stdio[2])
+            let processStdin = try duplicateFileHandle(stdin)
+            let processStdout = try duplicateFileHandle(stdout)
+            let processStderr = try duplicateFileHandle(stderr)
 
             return ScriptedProcess(
                 id: "exec-sync-capture",
                 onStart: {
-                    let received = try stdin.readToEnd() ?? Data()
-                    try stdout.write(contentsOf: received)
-                    try stderr.write(contentsOf: Data("stderr bytes".utf8))
+                    DispatchQueue.global().async {
+                        do {
+                            defer {
+                                try? processStdin.close()
+                                try? processStdout.close()
+                                try? processStderr.close()
+                            }
+
+                            let received = try processStdin.readToEnd() ?? Data()
+                            try processStdout.write(contentsOf: received)
+                            try processStderr.write(contentsOf: Data("stderr bytes".utf8))
+                            state.finish(.success(23))
+                        } catch {
+                            state.finish(.failure(error))
+                        }
+                    }
                 },
                 onWait: {
-                    23
+                    try await state.wait()
                 }
             )
         }
@@ -101,6 +119,55 @@ private final class ScriptedProcess: ClientProcess, @unchecked Sendable {
     }
 }
 
+private func duplicateFileHandle(_ handle: FileHandle) throws -> FileHandle {
+    let duplicatedFD = dup(handle.fileDescriptor)
+    guard duplicatedFD >= 0 else {
+        throw NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(errno))]
+        )
+    }
+    return FileHandle(fileDescriptor: duplicatedFD, closeOnDealloc: true)
+}
+
+private final class CapturingProcessState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<Int32, Error>?
+    private var waitContinuation: CheckedContinuation<Result<Int32, Error>, Never>?
+
+    func finish(_ result: Result<Int32, Error>) {
+        let continuation = lock.withLock { () -> CheckedContinuation<Result<Int32, Error>, Never>? in
+            if let waitContinuation {
+                self.waitContinuation = nil
+                return waitContinuation
+            }
+
+            self.result = result
+            return nil
+        }
+
+        continuation?.resume(returning: result)
+    }
+
+    func wait() async throws -> Int32 {
+        if let result = lock.withLock({ self.result }) {
+            return try result.get()
+        }
+
+        let result = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Int32, Error>, Never>) in
+            lock.withLock {
+                if let result = self.result {
+                    continuation.resume(returning: result)
+                    return
+                }
+                waitContinuation = continuation
+            }
+        }
+        return try result.get()
+    }
+}
+
 private actor HangingProcessState {
     private var signals: [Int32] = []
     private var waitContinuation: CheckedContinuation<Int32, Never>?
@@ -143,5 +210,13 @@ private final class HangingProcess: ClientProcess, @unchecked Sendable {
 
     func wait() async throws -> Int32 {
         await state.wait()
+    }
+}
+
+extension NSLock {
+    fileprivate func withLock<R>(_ body: () -> R) -> R {
+        lock()
+        defer { unlock() }
+        return body()
     }
 }

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -16,6 +16,7 @@
 
 import ContainerizationError
 import ContainerizationExtras
+import Dispatch
 import Foundation
 import Testing
 
@@ -725,15 +726,16 @@ struct ParserTest {
         defer { try? FileManager.default.removeItem(at: pipePath) }
 
         let group = DispatchGroup()
+        let writerError = LockedValue<Error?>(nil)
 
         group.enter()
-        DispatchQueue.global().async {
+        DispatchQueue.global(qos: .userInitiated).async {
             do {
                 let handle = try FileHandle(forWritingTo: pipePath)
                 try handle.write(contentsOf: "SECRET_KEY=value123\n".data(using: .utf8)!)
                 try handle.close()
             } catch {
-                Issue.record(error)
+                writerError.withLock { $0 = error }
             }
             group.leave()
         }
@@ -742,7 +744,10 @@ struct ParserTest {
         let lines = try Parser.envFile(path: pipePath.path)
 
         // Wait for write to complete
-        group.wait()
+        #expect(group.wait(timeout: .now() + .seconds(1)) == .success)
+        if let error = writerError.withLock({ $0 }) {
+            throw error
+        }
 
         #expect(lines == ["SECRET_KEY=value123"])
     }
@@ -1020,5 +1025,20 @@ struct ParserTest {
         #expect(result[0].limit == "RLIMIT_NPROC")
         #expect(result[0].soft == UInt64.max - 1)
         #expect(result[0].hard == UInt64.max)
+    }
+}
+
+private final class LockedValue<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+
+    func withLock<R>(_ body: (inout T) -> R) -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&value)
     }
 }

--- a/Tests/MacOSGuestAgentTests/GuestAgentFileTransferTransactionTests.swift
+++ b/Tests/MacOSGuestAgentTests/GuestAgentFileTransferTransactionTests.swift
@@ -368,6 +368,21 @@ struct GuestAgentFileTransferTransactionTests {
     }
 
     @Test
+    func execIdentityMatchingCurrentProcessDoesNotRequireSpawnedSession() throws {
+        let resolved = try GuestAgentExecIdentity.resolve(
+            from: .init(
+                type: .exec,
+                executable: "/usr/bin/id",
+                uid: UInt32(geteuid()),
+                gid: UInt32(getegid())
+            )
+        )
+        let identity = try #require(resolved)
+
+        #expect(identity.requiresSpawnedSession() == false)
+    }
+
+    @Test
     func execIdentityRejectsUnknownNamedUser() throws {
         let unknownUser = "codex-user-\(UUID().uuidString)"
 
@@ -420,7 +435,7 @@ struct GuestAgentFileTransferTransactionTests {
     }
 
     @Test
-    func ttyCloseDeliversEOFToSpawnedProcessSession() throws {
+    func ttyCloseDeliversEOFToCurrentIdentityExec() throws {
         let (serverFD, clientSocket) = try socketPair()
         let connection = AgentConnection(fd: serverFD)
         var clientFD = clientSocket

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSImageBackedWorkloadTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSImageBackedWorkloadTests.swift
@@ -648,10 +648,14 @@ private final class RecordingSidecarServer: @unchecked Sendable {
                 }
                 clientFD.withLock { $0 = accepted }
                 defer {
-                    clientFD.withLock { fd in
-                        if fd == accepted { fd = nil }
+                    let ownedClientFD = clientFD.withLock { fd -> Int32? in
+                        guard fd == accepted else {
+                            return nil
+                        }
+                        fd = nil
+                        return accepted
                     }
-                    Darwin.close(accepted)
+                    closeIfValid(ownedClientFD)
                 }
 
                 while true {
@@ -700,12 +704,14 @@ private final class RecordingSidecarServer: @unchecked Sendable {
             fd = nil
             return current
         }
-        clientFD.withLock { fd in
-            if let fd, fd >= 0 {
-                _ = Darwin.shutdown(fd, SHUT_RDWR)
-                Darwin.close(fd)
-            }
+        let clientFDToClose = clientFD.withLock { fd -> Int32? in
+            let current = fd
             fd = nil
+            return current
+        }
+        if let clientFDToClose, clientFDToClose >= 0 {
+            _ = Darwin.shutdown(clientFDToClose, SHUT_RDWR)
+            Darwin.close(clientFDToClose)
         }
         if let listeningFD {
             _ = Darwin.shutdown(listeningFD, SHUT_RDWR)
@@ -798,5 +804,12 @@ private func writeResponse(_ response: MacOSSidecarResponse, to fd: Int32) throw
 
 private func writeEvent(_ event: MacOSSidecarEvent, to fd: Int32) throws {
     try MacOSSidecarSocketIO.writeJSONFrame(MacOSSidecarEnvelope.event(event), fd: fd)
+}
+
+private func closeIfValid(_ fd: Int32?) {
+    guard let fd, fd >= 0 else {
+        return
+    }
+    Darwin.close(fd)
 }
 #endif

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceWaiterTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceWaiterTests.swift
@@ -86,6 +86,35 @@ struct MacOSSandboxServiceWaiterTests {
     }
 
     @Test
+    func timedWaitDoesNotResumeOtherWaiters() async throws {
+        let tempRoot = makeTemporaryRoot()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let service = makeSandboxService(root: tempRoot)
+        await service.testingAddSession(id: "exec-shared", config: baseProcessConfiguration())
+
+        let longWait = Task {
+            try await service.testingWaitForProcess("exec-shared")
+        }
+        try await waitUntilWaiterRegistered(service: service, id: "exec-shared")
+
+        do {
+            _ = try await service.testingWaitForProcess("exec-shared", timeout: 1)
+            Issue.record("expected timed wait to throw timeout")
+        } catch let error as ContainerizationError {
+            #expect(error.code == .timeout)
+        }
+
+        #expect(await service.testingWaiterCount(for: "exec-shared") == 1)
+
+        await service.testingCloseAllSessions()
+
+        let status = try await longWait.value
+        #expect(status.exitCode == 255)
+        #expect(await service.testingWaiterCount(for: "exec-shared") == 0)
+    }
+
+    @Test
     func workloadSnapshotReportsStatusExitCodeAndLogPaths() async throws {
         let tempRoot = makeTemporaryRoot()
         defer { try? FileManager.default.removeItem(at: tempRoot) }
@@ -920,12 +949,14 @@ private final class RecordingExecSidecarServer: @unchecked Sendable {
                 }
                 clientFD.withLock { $0 = accepted }
                 defer {
-                    clientFD.withLock { fd in
-                        if fd == accepted {
-                            fd = nil
+                    let ownedClientFD = clientFD.withLock { fd -> Int32? in
+                        guard fd == accepted else {
+                            return nil
                         }
+                        fd = nil
+                        return accepted
                     }
-                    Darwin.close(accepted)
+                    closeIfValid(ownedClientFD)
                 }
 
                 while true {
@@ -977,12 +1008,14 @@ private final class RecordingExecSidecarServer: @unchecked Sendable {
             fd = nil
             return current
         }
-        clientFD.withLock { fd in
-            if let fd, fd >= 0 {
-                _ = Darwin.shutdown(fd, SHUT_RDWR)
-                Darwin.close(fd)
-            }
+        let clientFDToClose = clientFD.withLock { fd -> Int32? in
+            let current = fd
             fd = nil
+            return current
+        }
+        if let clientFDToClose, clientFDToClose >= 0 {
+            _ = Darwin.shutdown(clientFDToClose, SHUT_RDWR)
+            Darwin.close(clientFDToClose)
         }
         if let listeningFD {
             _ = Darwin.shutdown(listeningFD, SHUT_RDWR)
@@ -1070,6 +1103,13 @@ private func writeResponse(_ response: MacOSSidecarResponse, to fd: Int32) throw
 
 private func writeEvent(_ event: MacOSSidecarEvent, to fd: Int32) throws {
     try MacOSSidecarSocketIO.writeJSONFrame(MacOSSidecarEnvelope.event(event), fd: fd)
+}
+
+private func closeIfValid(_ fd: Int32?) {
+    guard let fd, fd >= 0 else {
+        return
+    }
+    Darwin.close(fd)
 }
 
 private func waitUntilWaiterRegistered(

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSSidecarClientTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSSidecarClientTests.swift
@@ -308,6 +308,50 @@ struct MacOSSidecarClientTests {
     }
 
     @Test
+    func pendingRequestTimesOutWhenSidecarStopsResponding() throws {
+        let socketPath = try makeTemporarySocketPath()
+        let server = try FakeUnixSidecarTestServer(socketPath: socketPath)
+        defer { server.stop() }
+
+        server.start { clientFD in
+            let bootstrap = try readRequest(from: clientFD)
+            #expect(bootstrap.method == .vmBootstrapStart)
+            try writeResponse(.success(requestID: bootstrap.requestID), to: clientFD)
+
+            let begin = try readRequest(from: clientFD)
+            #expect(begin.method == .fsBegin)
+            usleep(300_000)
+        }
+
+        let client = MacOSSidecarClient(
+            socketPath: socketPath,
+            log: Logger(label: "MacOSSidecarClientTests"),
+            requestTimeoutSeconds: 0.1
+        )
+        defer { client.closeControlConnection() }
+        try client.bootstrapStart(socketConnectRetries: 3)
+
+        do {
+            try client.fsBegin(
+                port: 27000,
+                request: .init(
+                    txID: "tx-timeout",
+                    op: .writeFile,
+                    path: "/tmp/timeout.txt",
+                    inlineData: Data("payload".utf8),
+                    autoCommit: true
+                )
+            )
+            Issue.record("expected fsBegin to time out when the sidecar stops responding")
+        } catch let error as ContainerizationError {
+            #expect(error.code == .timeout)
+            #expect(error.message.contains("fs.begin"))
+        }
+
+        try server.waitForCompletion()
+    }
+
+    @Test
     func sidecarEventPumpPreservesEventOrder() async {
         let pump = SidecarEventPump()
         let recorder = EventRecorder()
@@ -373,10 +417,14 @@ private final class FakeUnixSidecarTestServer: @unchecked Sendable {
                 }
                 activeClientFD.withLock { $0 = clientFD }
                 defer {
-                    activeClientFD.withLock { fd in
-                        if fd == clientFD { fd = nil }
+                    let ownedClientFD = activeClientFD.withLock { fd -> Int32? in
+                        guard fd == clientFD else {
+                            return nil
+                        }
+                        fd = nil
+                        return clientFD
                     }
-                    Darwin.close(clientFD)
+                    closeIfValid(ownedClientFD)
                 }
                 try handler(clientFD)
             } catch {
@@ -401,12 +449,14 @@ private final class FakeUnixSidecarTestServer: @unchecked Sendable {
         self.listenFD = -1
         stateLock.unlock()
 
-        activeClientFD.withLock { fd in
-            if let fd, fd >= 0 {
-                _ = Darwin.shutdown(fd, SHUT_RDWR)
-                Darwin.close(fd)
-            }
+        let clientFDToClose = activeClientFD.withLock { fd -> Int32? in
+            let current = fd
             fd = nil
+            return current
+        }
+        if let clientFDToClose, clientFDToClose >= 0 {
+            _ = Darwin.shutdown(clientFDToClose, SHUT_RDWR)
+            Darwin.close(clientFDToClose)
         }
         if listenFD >= 0 {
             _ = Darwin.shutdown(listenFD, SHUT_RDWR)

--- a/Tests/SocketForwarderTests/EventLoopGroupHelpers.swift
+++ b/Tests/SocketForwarderTests/EventLoopGroupHelpers.swift
@@ -192,9 +192,14 @@ private func closeForwarder(
         _ = serverChannel.close(mode: .all)
     }
     try await serverChannel.closeFuture.get()
+    try await waitForEventLoopQuiescence(on: serverChannel.eventLoop)
 
     forwarderResult.close()
     try await forwarderResult.wait()
+}
+
+private func waitForEventLoopQuiescence(on eventLoop: any EventLoop) async throws {
+    try await eventLoop.submit {}.get()
 }
 
 private func isTransientSocketError(_ error: Error) -> Bool {


### PR DESCRIPTION
## Summary
- fix the ExecSync test double so it no longer blocks `start()` on stdin reads
- make SocketForwarder shutdown wait for in-flight backend bootstrap work and listener event-loop quiescence
- fix sidecar test servers to transfer ownership of accepted UNIX socket FDs so `stop()` and thread cleanup cannot double-close a reused fd

## Root cause
Recent CI failures were not one issue:
- `ExecSyncTests` could deadlock because the fake process synchronously called `readToEnd()` inside `start()` while `ExecSyncRunner` wrote stdin from a separate task
- `SocketForwarder` cleanup only tracked open channels, not in-flight TCP/UDP backend bootstrap operations, so shutdown could race with NIO channel initialization
- several sidecar test servers could close the same accepted UNIX socket twice; once the fd number was reused by NIO, unrelated socket tests crashed with `EBADF`

## Validation
- `make fmt`
- `swift test -c debug -Xswiftc -warnings-as-errors --skip TestCLI --filter 'SocketForwarderStressTests|ExecSyncTests'`
- 10x full repeats (`swift test ... --skip TestCLI`, first run with build, then 9x `--skip-build`) all passed locally
