### PR TITLE
Fix macOS sidecar bootstrap timeout on first run

### DIFF
--- a/Sources/Helpers/RuntimeMacOS/MacOSSandboxService+Sidecar.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSandboxService+Sidecar.swift
@@ -21,7 +21,7 @@ import Foundation
 import RuntimeMacOSSidecarShared
 
 extension MacOSSandboxService {
-    private static let sidecarBootstrapStartTimeoutSeconds: TimeInterval = 30.0
+    private static let sidecarBootstrapStartTimeoutSeconds: TimeInterval = 120.0
 
     func sidecarSocketPath(config: ContainerConfiguration) -> URL {
         URL(fileURLWithPath: "/tmp/ctrm-sidecar-\(config.id).sock")

--- a/Sources/Helpers/RuntimeMacOS/MacOSSidecarClient.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSidecarClient.swift
@@ -21,7 +21,7 @@ import Logging
 import RuntimeMacOSSidecarShared
 
 final class MacOSSidecarClient: @unchecked Sendable {
-    private static let defaultBootstrapStartTimeoutSeconds: TimeInterval = 30.0
+    private static let defaultBootstrapStartTimeoutSeconds: TimeInterval = 120.0
 
     private final class PendingResponse: @unchecked Sendable {
         let semaphore = DispatchSemaphore(value: 0)

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSSidecarClientTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSSidecarClientTests.swift
@@ -352,6 +352,53 @@ struct MacOSSidecarClientTests {
     }
 
     @Test
+    func bootstrapStartUsesDedicatedTimeoutBudget() throws {
+        let socketPath = try makeTemporarySocketPath()
+        let server = try FakeUnixSidecarTestServer(socketPath: socketPath)
+        defer { server.stop() }
+
+        server.start { clientFD in
+            let bootstrap = try readRequest(from: clientFD)
+            #expect(bootstrap.method == .vmBootstrapStart)
+            usleep(250_000)
+            try writeResponse(.success(requestID: bootstrap.requestID), to: clientFD)
+
+            let begin = try readRequest(from: clientFD)
+            #expect(begin.method == .fsBegin)
+            usleep(250_000)
+        }
+
+        let client = MacOSSidecarClient(
+            socketPath: socketPath,
+            log: Logger(label: "MacOSSidecarClientTests"),
+            requestTimeoutSeconds: 0.1,
+            bootstrapStartTimeoutSeconds: 0.6
+        )
+        defer { client.closeControlConnection() }
+
+        try client.bootstrapStart(socketConnectRetries: 3)
+
+        do {
+            try client.fsBegin(
+                port: 27000,
+                request: .init(
+                    txID: "tx-bootstrap-timeout",
+                    op: .writeFile,
+                    path: "/tmp/bootstrap-timeout.txt",
+                    inlineData: Data("payload".utf8),
+                    autoCommit: true
+                )
+            )
+            Issue.record("expected fsBegin to keep using the default request timeout")
+        } catch let error as ContainerizationError {
+            #expect(error.code == .timeout)
+            #expect(error.message.contains("fs.begin"))
+        }
+
+        try server.waitForCompletion()
+    }
+
+    @Test
     func sidecarEventPumpPreservesEventOrder() async {
         let pump = SidecarEventPump()
         let recorder = EventRecorder()


### PR DESCRIPTION
## Summary
- give vm.bootstrapStart its own longer timeout budget so first boot of a freshly built macOS image can finish
- keep the shorter default timeout for normal sidecar requests so later failures still surface quickly
- add a regression test covering the split timeout behavior

## Testing
- make fmt
- swift test --filter MacOSSidecarClientTests

Fixes #6