### PR TITLE
docs: update macos node usage guide

### DIFF
--- a/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
@@ -38,6 +38,8 @@ public struct CRIShimRuntimeVersionInfo: Equatable, Sendable {
     }
 }
 
+private let criShimPodSandboxStopOptions = ContainerStopOptions(timeoutInSeconds: 30, signal: SIGTERM)
+
 public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsyncProvider, @unchecked Sendable {
     public var versionInfo: CRIShimRuntimeVersionInfo
     public var config: CRIShimConfig
@@ -701,7 +703,7 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
                     try await runtimeManager.stopWorkload(
                         sandboxID: metadata.id,
                         workloadID: container.id,
-                        options: .default
+                        options: criShimPodSandboxStopOptions
                     )
                 } catch {
                     if !isNotFound(error) {
@@ -721,7 +723,7 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
 
         if metadata.state != .stopped {
             do {
-                try await runtimeManager.stopSandbox(id: metadata.id, options: .default)
+                try await runtimeManager.stopSandbox(id: metadata.id, options: criShimPodSandboxStopOptions)
             } catch {
                 if !isNotFound(error) {
                     record(error)

--- a/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
@@ -142,7 +142,7 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
 
             let handler = try config.resolveRuntimeHandler(request.runtimeHandler)
             let sandboxID = UUID().uuidString.lowercased()
-            let sandboxImage = try await findImage(reference: handler.sandboxImage)
+            let sandboxImage = try await resolveSandboxImage(reference: handler.sandboxImage)
             try validateCRIShimImage(
                 sandboxImage,
                 expectedRole: .sandbox,
@@ -762,12 +762,23 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
         try metadataStore.upsertSandbox(metadata)
     }
 
-    private func findImage(reference: String) async throws -> CRIShimImageRecord {
-        let images = try await imageManager.listImages()
-        guard let image = images.first(where: { $0.matches(reference: reference) }) else {
-            throw CRIShimError.notFound("image not found: \(reference)")
+    private func resolveSandboxImage(reference: String) async throws -> CRIShimImageRecord {
+        if let image = try await findOptionalImage(reference: reference) {
+            return image
         }
-        return image
+        return try await imageManager.pullImage(reference: reference, authentication: nil)
+    }
+
+    private func findImage(reference: String) async throws -> CRIShimImageRecord {
+        if let image = try await findOptionalImage(reference: reference) {
+            return image
+        }
+        throw CRIShimError.notFound("image not found: \(reference)")
+    }
+
+    private func findOptionalImage(reference: String) async throws -> CRIShimImageRecord? {
+        let images = try await imageManager.listImages()
+        return images.first(where: { $0.matches(reference: reference) })
     }
 }
 

--- a/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
@@ -817,8 +817,17 @@ private func isNotFound(_ error: any Error) -> Bool {
     if nsError.domain == NSPOSIXErrorDomain && nsError.code == Int(POSIXErrorCode.ENOENT.rawValue) {
         return true
     }
+    if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? any Error, isNotFound(underlyingError) {
+        return true
+    }
     let description = String(describing: error)
     if description.contains("notFound:") {
+        return true
+    }
+    if description.contains("NSCocoaErrorDomain Code=\(NSFileNoSuchFileError)")
+        || description.contains("NSPOSIXErrorDomain Code=\(Int(POSIXErrorCode.ENOENT.rawValue))")
+        || description.contains("No such file or directory")
+    {
         return true
     }
     return false

--- a/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
@@ -40,6 +40,10 @@ public struct CRIShimRuntimeVersionInfo: Equatable, Sendable {
 
 private let criShimPodSandboxStopOptions = ContainerStopOptions(timeoutInSeconds: 30, signal: SIGTERM)
 
+public enum CRIShimPodAnnotation {
+    public static let sandboxImage = "container-macos.io/sandbox-image"
+}
+
 public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsyncProvider, @unchecked Sendable {
     public var versionInfo: CRIShimRuntimeVersionInfo
     public var config: CRIShimConfig
@@ -142,7 +146,8 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
         try await handlerLogger.handle(operation: CRIRuntimeOperation.runPodSandbox.rawValue) {
             try CRIShimUnsupportedFieldValidator.validate(request)
 
-            let handler = try config.resolveRuntimeHandler(request.runtimeHandler)
+            var handler = try config.resolveRuntimeHandler(request.runtimeHandler)
+            handler.sandboxImage = try sandboxImageReference(request: request, handler: handler)
             let sandboxID = UUID().uuidString.lowercased()
             let sandboxImage = try await resolveSandboxImage(reference: handler.sandboxImage)
             try validateCRIShimImage(
@@ -769,6 +774,20 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
             return image
         }
         return try await imageManager.pullImage(reference: reference, authentication: nil)
+    }
+
+    private func sandboxImageReference(
+        request: Runtime_V1_RunPodSandboxRequest,
+        handler: ResolvedRuntimeHandler
+    ) throws -> String {
+        guard let override = request.config.annotations[CRIShimPodAnnotation.sandboxImage] else {
+            return handler.sandboxImage
+        }
+        let reference = override.trimmed
+        guard !reference.isEmpty else {
+            throw CRIShimError.invalidArgument("\(CRIShimPodAnnotation.sandboxImage) annotation must not be empty")
+        }
+        return reference
     }
 
     private func findImage(reference: String) async throws -> CRIShimImageRecord {

--- a/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
@@ -808,6 +808,13 @@ private func isNotFound(_ error: any Error) -> Bool {
     if let error = error as? ContainerizationError, let cause = error.cause {
         return isNotFound(cause)
     }
+    let nsError = error as NSError
+    if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError {
+        return true
+    }
+    if nsError.domain == NSPOSIXErrorDomain && nsError.code == Int(POSIXErrorCode.ENOENT.rawValue) {
+        return true
+    }
     let description = String(describing: error)
     if description.contains("notFound:") {
         return true

--- a/Sources/ContainerCRIShimMacOS/CRIShimStreamingServer.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimStreamingServer.swift
@@ -83,7 +83,21 @@ private struct CRIShimPreparedWebSocketUpgrade: Sendable {
 
 private struct CRIShimPreparedSPDYUpgrade: Sendable {
     var protocolVersion: String
-    var handler: CRIShimPortForwardSPDYHandler
+    var handler: CRIShimSPDYHandler
+
+    func addHandler(to pipeline: ChannelPipeline) throws {
+        switch handler {
+        case .exec(let handler):
+            try pipeline.syncOperations.addHandler(handler)
+        case .portForward(let handler):
+            try pipeline.syncOperations.addHandler(handler)
+        }
+    }
+}
+
+private enum CRIShimSPDYHandler: Sendable {
+    case exec(CRIShimExecSPDYHandler)
+    case portForward(CRIShimPortForwardSPDYHandler)
 }
 
 private struct CRIShimStreamingPath {
@@ -307,41 +321,58 @@ public final class CRIShimStreamingServer: @unchecked Sendable {
         requestHead: HTTPRequestHead
     ) async throws -> CRIShimPreparedSPDYUpgrade {
         let path = try parseStreamingPath(requestHead.uri)
-        guard path.route == .portForward else {
-            throw CRIShimStreamingHTTPError(status: .badRequest, message: "SPDY upgrade is only supported for port-forward")
-        }
         guard let preview = await sessionStore.peek(token: path.token) else {
             throw CRIShimStreamingHTTPError(status: .notFound, message: "stream token not found")
         }
-        guard case .portForward(let invocation) = preview else {
-            throw CRIShimStreamingHTTPError(status: .badRequest, message: "SPDY upgrade is only supported for port-forward")
-        }
-
         let offeredProtocols = spdyStreamProtocols(from: requestHead.headers)
-        guard offeredProtocols.contains(criShimPortForwardProtocol) else {
-            throw CRIShimStreamingHTTPError(
-                status: .badRequest,
-                message: "\(criShimSPDYStreamProtocolHeader) must include \(criShimPortForwardProtocol)"
+
+        switch (path.route, preview) {
+        case (.exec, .exec(let invocation)):
+            guard let protocolVersion = CRIShimExecStreamProtocol.negotiate(offered: offeredProtocols) else {
+                throw CRIShimStreamingHTTPError(
+                    status: .badRequest,
+                    message: "\(criShimSPDYStreamProtocolHeader) must include a supported exec protocol"
+                )
+            }
+            guard let session = await sessionStore.consume(token: path.token), case .exec = session else {
+                throw CRIShimStreamingHTTPError(status: .notFound, message: "stream token not found")
+            }
+            let handler = CRIShimExecSPDYHandler(
+                server: self,
+                runtimeManager: runtimeManager,
+                invocation: invocation,
+                protocolVersion: protocolVersion,
+                idleTimeout: activeSessionIdleTimeout
             )
-        }
+            return CRIShimPreparedSPDYUpgrade(
+                protocolVersion: protocolVersion.rawValue,
+                handler: .exec(handler)
+            )
 
-        guard let session = await sessionStore.consume(token: path.token) else {
+        case (.portForward, .portForward(let invocation)):
+            guard offeredProtocols.contains(criShimPortForwardProtocol) else {
+                throw CRIShimStreamingHTTPError(
+                    status: .badRequest,
+                    message: "\(criShimSPDYStreamProtocolHeader) must include \(criShimPortForwardProtocol)"
+                )
+            }
+            guard let session = await sessionStore.consume(token: path.token), case .portForward = session else {
+                throw CRIShimStreamingHTTPError(status: .notFound, message: "stream token not found")
+            }
+            let handler = CRIShimPortForwardSPDYHandler(
+                server: self,
+                runtimeManager: runtimeManager,
+                invocation: invocation,
+                idleTimeout: activeSessionIdleTimeout
+            )
+            return CRIShimPreparedSPDYUpgrade(
+                protocolVersion: criShimPortForwardProtocol,
+                handler: .portForward(handler)
+            )
+
+        default:
             throw CRIShimStreamingHTTPError(status: .notFound, message: "stream token not found")
         }
-        guard case .portForward = session else {
-            throw CRIShimStreamingHTTPError(status: .notFound, message: "stream token not found")
-        }
-
-        let handler = CRIShimPortForwardSPDYHandler(
-            server: self,
-            runtimeManager: runtimeManager,
-            invocation: invocation,
-            idleTimeout: activeSessionIdleTimeout
-        )
-        return CRIShimPreparedSPDYUpgrade(
-            protocolVersion: criShimPortForwardProtocol,
-            handler: handler
-        )
     }
 
     fileprivate func plainHTTPRequestError(
@@ -563,8 +594,628 @@ private final class CRIShimSPDYServerUpgrader: HTTPServerProtocolUpgrader, @unch
             removeRequestHandler = context.eventLoop.makeSucceededFuture(())
         }
         return removeRequestHandler.flatMapThrowing {
-            try pipeline.syncOperations.addHandler(preparedUpgrade.handler)
+            try preparedUpgrade.addHandler(to: pipeline)
         }
+    }
+}
+
+private final class CRIShimExecSPDYHandler: ChannelInboundHandler, RemovableChannelHandler, @unchecked Sendable {
+    typealias InboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    fileprivate enum StreamKind: String, Hashable {
+        case error
+        case stdin
+        case stdout
+        case stderr
+        case resize
+    }
+
+    private let server: CRIShimStreamingServer
+    private let runtimeManager: any CRIShimRuntimeManaging
+    private let invocation: CRIShimExecStreamingInvocation
+    private let protocolVersion: CRIShimExecStreamProtocol
+    private let idleTimeout: TimeAmount?
+    private let lock = NSLock()
+    private var channel: Channel?
+    private var inboundBuffer: ByteBuffer?
+    private var streamsByID: [UInt32: StreamKind] = [:]
+    private var streamIDsByKind: [StreamKind: UInt32] = [:]
+    private var stdinPipe: Pipe?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+    private var process: (any CRIShimStreamingProcess)?
+    private var pendingStdin = Data()
+    private var pendingResizes: [CRIShimTerminalSize] = []
+    private var stdinClosed = false
+    private var processStarting = false
+    private var tasks: [Task<Void, Never>] = []
+    private var cleanupPerformed = false
+    private var idleTimeoutTask: Scheduled<Void>?
+    private var inflater = try! CRIShimSPDYHeaderInflater()
+    private var deflater = try! CRIShimSPDYHeaderDeflater()
+
+    init(
+        server: CRIShimStreamingServer,
+        runtimeManager: any CRIShimRuntimeManaging,
+        invocation: CRIShimExecStreamingInvocation,
+        protocolVersion: CRIShimExecStreamProtocol,
+        idleTimeout: TimeAmount?
+    ) {
+        self.server = server
+        self.runtimeManager = runtimeManager
+        self.invocation = invocation
+        self.protocolVersion = protocolVersion
+        self.idleTimeout = idleTimeout
+    }
+
+    func handlerAdded(context: ChannelHandlerContext) {
+        channel = context.channel
+        inboundBuffer = context.channel.allocator.buffer(capacity: 0)
+        recordActivity()
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        var incoming = unwrapInboundIn(data)
+        inboundBuffer?.writeBuffer(&incoming)
+        recordActivity()
+        do {
+            try parseAvailableFrames()
+        } catch {
+            Task {
+                await failSession(String(describing: error))
+            }
+        }
+    }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        server.unregisterActiveChannel(context.channel)
+        Task {
+            await cleanup(killProcess: true)
+        }
+        context.fireChannelInactive()
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        Task {
+            await cleanup(killProcess: true)
+        }
+    }
+
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        server.unregisterActiveChannel(context.channel)
+        Task {
+            await cleanup(killProcess: true)
+        }
+        context.close(promise: nil)
+    }
+
+    private var expectedStreamKinds: Set<StreamKind> {
+        var kinds: Set<StreamKind> = [.error]
+        if invocation.stdin {
+            kinds.insert(.stdin)
+        }
+        if invocation.stdout {
+            kinds.insert(.stdout)
+        }
+        if invocation.stderr && !invocation.tty {
+            kinds.insert(.stderr)
+        }
+        if invocation.tty && protocolVersion.supportsResize {
+            kinds.insert(.resize)
+        }
+        return kinds
+    }
+
+    private func parseAvailableFrames() throws {
+        guard var buffer = inboundBuffer else {
+            return
+        }
+
+        while true {
+            guard buffer.readableBytes >= 8 else {
+                break
+            }
+            let frameStart = buffer.readerIndex
+            guard
+                let firstWord = buffer.getInteger(at: frameStart, endianness: .big, as: UInt32.self),
+                let flagsAndLength = buffer.getInteger(at: frameStart + 4, endianness: .big, as: UInt32.self)
+            else {
+                break
+            }
+            let length = Int(flagsAndLength & 0x00FF_FFFF)
+            guard buffer.readableBytes >= 8 + length else {
+                break
+            }
+
+            buffer.moveReaderIndex(forwardBy: 8)
+            guard var payload = buffer.readSlice(length: length) else {
+                break
+            }
+            let flags = UInt8((flagsAndLength & 0xFF00_0000) >> 24)
+            if (firstWord & 0x8000_0000) != 0 {
+                let version = UInt16((firstWord >> 16) & 0x7FFF)
+                let frameType = UInt16(firstWord & 0xFFFF)
+                try handleControlFrame(version: version, type: frameType, flags: flags, payload: &payload)
+            } else {
+                let streamID = firstWord & 0x7FFF_FFFF
+                handleDataFrame(streamID: streamID, flags: flags, payload: payload)
+            }
+        }
+
+        buffer.discardReadBytes()
+        inboundBuffer = buffer
+    }
+
+    private func handleControlFrame(
+        version: UInt16,
+        type: UInt16,
+        flags: UInt8,
+        payload: inout ByteBuffer
+    ) throws {
+        guard version == 3 else {
+            throw CRIShimError.invalidArgument("unsupported SPDY version \(version)")
+        }
+
+        switch type {
+        case 1:
+            try handleSynStream(flags: flags, payload: &payload)
+        case 3:
+            handleRstStream(payload: &payload)
+        case 4:
+            break
+        case 6:
+            try handlePing(payload: &payload)
+        case 7:
+            Task {
+                await cleanup(killProcess: true)
+            }
+        case 9:
+            break
+        default:
+            break
+        }
+    }
+
+    private func handleSynStream(
+        flags: UInt8,
+        payload: inout ByteBuffer
+    ) throws {
+        guard
+            let rawStreamID = payload.readInteger(endianness: .big, as: UInt32.self),
+            payload.readInteger(endianness: .big, as: UInt32.self) != nil,
+            payload.readInteger(endianness: .big, as: UInt8.self) != nil,
+            payload.readInteger(endianness: .big, as: UInt8.self) != nil
+        else {
+            throw CRIShimError.invalidArgument("SPDY SYN_STREAM payload is truncated")
+        }
+
+        let streamID = rawStreamID & 0x7FFF_FFFF
+        let headerData = Data(payload.readableBytesView)
+        let headers = try parseSPDYHeaders(try inflater.decompress(headerData))
+        guard
+            let streamType = headers["streamtype"]?.first,
+            let kind = execStreamKind(streamType),
+            acceptsStream(kind)
+        else {
+            try writeResetFrame(streamID: streamID, status: 1)
+            return
+        }
+
+        let registered = lock.withLock { () -> Bool in
+            guard streamsByID[streamID] == nil, streamIDsByKind[kind] == nil else {
+                return false
+            }
+            streamsByID[streamID] = kind
+            streamIDsByKind[kind] = streamID
+            return true
+        }
+        guard registered else {
+            try writeResetFrame(streamID: streamID, status: 1)
+            return
+        }
+
+        try writeSynReplyFrame(streamID: streamID)
+
+        if (flags & 0x01) != 0 {
+            handleStreamFinished(streamID)
+        }
+        startExecIfReady()
+    }
+
+    private func acceptsStream(_ kind: StreamKind) -> Bool {
+        switch kind {
+        case .error:
+            true
+        case .stdin:
+            invocation.stdin
+        case .stdout:
+            invocation.stdout
+        case .stderr:
+            invocation.stderr && !invocation.tty
+        case .resize:
+            invocation.tty && protocolVersion.supportsResize
+        }
+    }
+
+    private func handleRstStream(payload: inout ByteBuffer) {
+        guard let streamID = payload.readInteger(endianness: .big, as: UInt32.self) else {
+            return
+        }
+        handleStreamFinished(streamID & 0x7FFF_FFFF)
+    }
+
+    private func handlePing(payload: inout ByteBuffer) throws {
+        guard let pingID = payload.readInteger(endianness: .big, as: UInt32.self) else {
+            return
+        }
+        try writePingFrame(id: pingID)
+    }
+
+    private func handleDataFrame(
+        streamID: UInt32,
+        flags: UInt8,
+        payload: ByteBuffer
+    ) {
+        let data = Data(payload.readableBytesView)
+        let kind = lock.withLock { streamsByID[streamID] }
+        switch kind {
+        case .stdin:
+            handleStdinData(data)
+        case .resize:
+            handleResizeData(data)
+        case .error, .stdout, .stderr, .none:
+            break
+        }
+
+        if (flags & 0x01) != 0 {
+            handleStreamFinished(streamID)
+        }
+    }
+
+    private func handleStdinData(_ data: Data) {
+        guard !data.isEmpty else {
+            return
+        }
+        let handle = lock.withLock { () -> FileHandle? in
+            if let handle = stdinPipe?.fileHandleForWriting {
+                return handle
+            }
+            pendingStdin.append(data)
+            return nil
+        }
+        guard let handle else {
+            return
+        }
+        do {
+            try handle.write(contentsOf: data)
+        } catch {
+            Task {
+                await failSession(String(describing: error))
+            }
+        }
+    }
+
+    private func handleResizeData(_ data: Data) {
+        guard !data.isEmpty else {
+            return
+        }
+        do {
+            let size = try decodeTerminalSize(data)
+            let process = lock.withLock { self.process }
+            guard let process else {
+                lock.withLock {
+                    pendingResizes.append(size)
+                }
+                return
+            }
+            let task = Task {
+                do {
+                    try await process.resize(size)
+                } catch {
+                    await failSession(String(describing: error))
+                }
+            }
+            appendTask(task)
+        } catch {
+            Task {
+                await failSession(String(describing: error))
+            }
+        }
+    }
+
+    private func handleStreamFinished(_ streamID: UInt32) {
+        let (kind, handle) = lock.withLock { () -> (StreamKind?, FileHandle?) in
+            guard let kind = streamsByID[streamID] else {
+                return (nil, nil)
+            }
+            if kind == .stdin {
+                stdinClosed = true
+                return (kind, stdinPipe?.fileHandleForWriting)
+            }
+            return (kind, nil)
+        }
+        guard kind == .stdin else {
+            return
+        }
+        try? handle?.close()
+    }
+
+    private func startExecIfReady() {
+        let shouldStart = lock.withLock { () -> Bool in
+            guard !cleanupPerformed, !processStarting else {
+                return false
+            }
+            guard expectedStreamKinds.isSubset(of: Set(streamIDsByKind.keys)) else {
+                return false
+            }
+            processStarting = true
+            stdinPipe = invocation.stdin ? Pipe() : nil
+            stdoutPipe = invocation.stdout ? Pipe() : nil
+            stderrPipe = invocation.stderr && !invocation.tty ? Pipe() : nil
+            return true
+        }
+        guard shouldStart else {
+            return
+        }
+
+        let task = Task {
+            await runExecSession()
+        }
+        appendTask(task)
+    }
+
+    private func runExecSession() async {
+        do {
+            let stdio = lock.withLock {
+                [
+                    stdinPipe?.fileHandleForReading,
+                    stdoutPipe?.fileHandleForWriting,
+                    stderrPipe?.fileHandleForWriting,
+                ]
+            }
+            let process = try await runtimeManager.streamExec(
+                containerID: invocation.containerID,
+                configuration: invocation.configuration,
+                stdio: stdio
+            )
+
+            let startupState = lock.withLock {
+                self.process = process
+                return (
+                    stdinWriter: stdinPipe?.fileHandleForWriting,
+                    stdoutReader: stdoutPipe?.fileHandleForReading,
+                    stderrReader: stderrPipe?.fileHandleForReading,
+                    pendingStdin: pendingStdin,
+                    pendingResizes: pendingResizes,
+                    stdinClosed: stdinClosed
+                )
+            }
+
+            if let stdinWriter = startupState.stdinWriter {
+                if !startupState.pendingStdin.isEmpty {
+                    try stdinWriter.write(contentsOf: startupState.pendingStdin)
+                }
+                if startupState.stdinClosed {
+                    try? stdinWriter.close()
+                }
+            }
+
+            var outputTasks: [Task<Void, Never>] = []
+            if let stdoutReader = startupState.stdoutReader {
+                outputTasks.append(
+                    Task {
+                        await pumpExecOutput(kind: .stdout, handle: stdoutReader)
+                    })
+            }
+            if let stderrReader = startupState.stderrReader {
+                outputTasks.append(
+                    Task {
+                        await pumpExecOutput(kind: .stderr, handle: stderrReader)
+                    })
+            }
+            for task in outputTasks {
+                appendTask(task)
+            }
+
+            try await process.start()
+            for size in startupState.pendingResizes {
+                try await process.resize(size)
+            }
+
+            let exitCode = try await process.wait()
+            try? stdoutPipe?.fileHandleForWriting.close()
+            try? stderrPipe?.fileHandleForWriting.close()
+            for task in outputTasks {
+                _ = await task.result
+            }
+            await sendExecExitStatus(exitCode: exitCode)
+            await closeChannel(killProcess: false)
+        } catch {
+            await failSession(String(describing: error))
+        }
+    }
+
+    private func pumpExecOutput(
+        kind: StreamKind,
+        handle: FileHandle
+    ) async {
+        guard let streamID = lock.withLock({ streamIDsByKind[kind] }) else {
+            return
+        }
+        for await data in fileHandleStream(handle) {
+            do {
+                try await writeDataFrame(streamID: streamID, data: data)
+                recordActivity()
+            } catch {
+                await failSession(String(describing: error))
+                return
+            }
+        }
+        try? await writeDataFrame(streamID: streamID, data: Data(), flags: 0x01)
+    }
+
+    private func sendExecExitStatus(exitCode: Int32) async {
+        let payload: Data
+        if protocolVersion.supportsStructuredExitStatus {
+            payload = makeStructuredExecStatus(exitCode: exitCode)
+        } else if exitCode == 0 {
+            payload = Data()
+        } else {
+            payload = Data("command terminated with exit code \(exitCode)".utf8)
+        }
+        guard let errorStreamID = lock.withLock({ streamIDsByKind[.error] }) else {
+            return
+        }
+        try? await writeDataFrame(streamID: errorStreamID, data: payload, flags: 0x01)
+    }
+
+    private func failSession(_ message: String) async {
+        fputs("container-cri-shim-macos SPDY exec failed: \(message)\n", stderr)
+        if let errorStreamID = lock.withLock({ streamIDsByKind[.error] }) {
+            let payload =
+                if protocolVersion.supportsStructuredExitStatus {
+                    makeStructuredExecFailureStatus(message: message)
+                } else {
+                    Data(message.utf8)
+                }
+            try? await writeDataFrame(streamID: errorStreamID, data: payload, flags: 0x01)
+        }
+        await closeChannel(killProcess: true)
+    }
+
+    private func closeChannel(killProcess: Bool) async {
+        await cleanup(killProcess: killProcess)
+        if let channel {
+            try? await channel.close().get()
+        }
+    }
+
+    private func cleanup(killProcess: Bool) async {
+        let cleanupState = lock.withLock {
+            () -> (
+                process: (any CRIShimStreamingProcess)?,
+                tasks: [Task<Void, Never>],
+                stdinPipe: Pipe?,
+                stdoutPipe: Pipe?,
+                stderrPipe: Pipe?
+            ) in
+            if cleanupPerformed {
+                return (nil, [], nil, nil, nil)
+            }
+            cleanupPerformed = true
+            idleTimeoutTask?.cancel()
+            idleTimeoutTask = nil
+            let cleanupState = (
+                process: process,
+                tasks: tasks,
+                stdinPipe: stdinPipe,
+                stdoutPipe: stdoutPipe,
+                stderrPipe: stderrPipe
+            )
+            tasks.removeAll()
+            streamsByID.removeAll()
+            streamIDsByKind.removeAll()
+            process = nil
+            stdinPipe = nil
+            stdoutPipe = nil
+            stderrPipe = nil
+            return cleanupState
+        }
+
+        for task in cleanupState.tasks {
+            task.cancel()
+        }
+        try? cleanupState.stdinPipe?.fileHandleForReading.close()
+        try? cleanupState.stdinPipe?.fileHandleForWriting.close()
+        try? cleanupState.stdoutPipe?.fileHandleForReading.close()
+        try? cleanupState.stdoutPipe?.fileHandleForWriting.close()
+        try? cleanupState.stderrPipe?.fileHandleForReading.close()
+        try? cleanupState.stderrPipe?.fileHandleForWriting.close()
+        if killProcess {
+            try? await cleanupState.process?.kill(SIGTERM)
+        }
+    }
+
+    private func appendTask(_ task: Task<Void, Never>) {
+        lock.withLock {
+            tasks.append(task)
+        }
+    }
+
+    private func recordActivity() {
+        guard let idleTimeout, let channel else {
+            return
+        }
+
+        let scheduled = channel.eventLoop.scheduleTask(in: idleTimeout) { [weak self] in
+            guard let self else {
+                return
+            }
+            Task {
+                await self.failSession("streaming session timed out due to inactivity")
+            }
+        }
+
+        let staleTask = lock.withLock { () -> Scheduled<Void>? in
+            guard !cleanupPerformed else {
+                scheduled.cancel()
+                return nil
+            }
+            let previous = idleTimeoutTask
+            idleTimeoutTask = scheduled
+            return previous
+        }
+        staleTask?.cancel()
+    }
+
+    private func writeSynReplyFrame(streamID: UInt32) throws {
+        let compressedHeaders = try deflater.compress(makeSPDYHeaderBlock([:]))
+        var payload = Data()
+        payload.append(contentsOf: spdyUInt32(streamID & 0x7FFF_FFFF))
+        payload.append(compressedHeaders)
+        try writeControlFrame(type: 2, flags: 0, payload: payload)
+    }
+
+    private func writeResetFrame(streamID: UInt32, status: UInt32) throws {
+        var payload = Data()
+        payload.append(contentsOf: spdyUInt32(streamID & 0x7FFF_FFFF))
+        payload.append(contentsOf: spdyUInt32(status))
+        try writeControlFrame(type: 3, flags: 0, payload: payload)
+    }
+
+    private func writePingFrame(id: UInt32) throws {
+        try writeControlFrame(type: 6, flags: 0, payload: Data(spdyUInt32(id)))
+    }
+
+    private func writeControlFrame(
+        type: UInt16,
+        flags: UInt8,
+        payload: Data
+    ) throws {
+        guard let channel else {
+            return
+        }
+        var buffer = channel.allocator.buffer(capacity: 8 + payload.count)
+        buffer.writeInteger(UInt32(0x8000_0000) | (UInt32(3) << 16) | UInt32(type), endianness: .big)
+        writeSPDYLength(flags: flags, length: payload.count, to: &buffer)
+        buffer.writeBytes(payload)
+        channel.writeAndFlush(buffer, promise: nil)
+    }
+
+    private func writeDataFrame(
+        streamID: UInt32,
+        data: Data,
+        flags: UInt8 = 0
+    ) async throws {
+        guard let channel else {
+            return
+        }
+        var buffer = channel.allocator.buffer(capacity: 8 + data.count)
+        buffer.writeInteger(streamID & 0x7FFF_FFFF, endianness: .big)
+        writeSPDYLength(flags: flags, length: data.count, to: &buffer)
+        buffer.writeBytes(data)
+        try await channel.writeAndFlush(buffer).get()
     }
 }
 
@@ -1701,6 +2352,23 @@ private func streamKind(_ value: String) -> CRIShimPortForwardSPDYHandler.Stream
         .data
     case "error":
         .error
+    default:
+        nil
+    }
+}
+
+private func execStreamKind(_ value: String) -> CRIShimExecSPDYHandler.StreamKind? {
+    switch value {
+    case "error":
+        .error
+    case "stdin":
+        .stdin
+    case "stdout":
+        .stdout
+    case "stderr":
+        .stderr
+    case "resize":
+        .resize
     default:
         nil
     }

--- a/Sources/ContainerCRIShimMacOS/CRIShimStreamingServer.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimStreamingServer.swift
@@ -1716,7 +1716,7 @@ private final class CRIShimPortForwardSPDYHandler: ChannelInboundHandler, Remova
     }
 
     private func handleWriteFailure() async {
-        await cleanup(killProcess: true)
+        await cleanup()
         guard let channel else {
             return
         }

--- a/Sources/ContainerCRIShimMacOS/CRIShimStreamingServer.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimStreamingServer.swift
@@ -1193,14 +1193,20 @@ private final class CRIShimExecSPDYHandler: ChannelInboundHandler, RemovableChan
         flags: UInt8,
         payload: Data
     ) throws {
-        guard let channel else {
+        guard let channel, channel.isActive else {
             return
         }
         var buffer = channel.allocator.buffer(capacity: 8 + payload.count)
         buffer.writeInteger(UInt32(0x8000_0000) | (UInt32(3) << 16) | UInt32(type), endianness: .big)
         writeSPDYLength(flags: flags, length: payload.count, to: &buffer)
         buffer.writeBytes(payload)
-        channel.writeAndFlush(buffer, promise: nil)
+        let promise = channel.eventLoop.makePromise(of: Void.self)
+        promise.futureResult.whenFailure { [weak self] _ in
+            Task {
+                await self?.handleWriteFailure()
+            }
+        }
+        channel.writeAndFlush(buffer, promise: promise)
     }
 
     private func writeDataFrame(
@@ -1208,14 +1214,27 @@ private final class CRIShimExecSPDYHandler: ChannelInboundHandler, RemovableChan
         data: Data,
         flags: UInt8 = 0
     ) async throws {
-        guard let channel else {
+        guard let channel, channel.isActive else {
             return
         }
         var buffer = channel.allocator.buffer(capacity: 8 + data.count)
         buffer.writeInteger(streamID & 0x7FFF_FFFF, endianness: .big)
         writeSPDYLength(flags: flags, length: data.count, to: &buffer)
         buffer.writeBytes(data)
-        try await channel.writeAndFlush(buffer).get()
+        do {
+            try await channel.writeAndFlush(buffer).get()
+        } catch {
+            await handleWriteFailure()
+            throw error
+        }
+    }
+
+    private func handleWriteFailure() async {
+        await cleanup(killProcess: true)
+        guard let channel else {
+            return
+        }
+        try? await channel.close().get()
     }
 }
 
@@ -1660,14 +1679,20 @@ private final class CRIShimPortForwardSPDYHandler: ChannelInboundHandler, Remova
         flags: UInt8,
         payload: Data
     ) throws {
-        guard let channel else {
+        guard let channel, channel.isActive else {
             return
         }
         var buffer = channel.allocator.buffer(capacity: 8 + payload.count)
         buffer.writeInteger(UInt32(0x8000_0000) | (UInt32(3) << 16) | UInt32(type), endianness: .big)
         writeSPDYLength(flags: flags, length: payload.count, to: &buffer)
         buffer.writeBytes(payload)
-        channel.writeAndFlush(buffer, promise: nil)
+        let promise = channel.eventLoop.makePromise(of: Void.self)
+        promise.futureResult.whenFailure { [weak self] _ in
+            Task {
+                await self?.handleWriteFailure()
+            }
+        }
+        channel.writeAndFlush(buffer, promise: promise)
     }
 
     private func writeDataFrame(
@@ -1675,14 +1700,27 @@ private final class CRIShimPortForwardSPDYHandler: ChannelInboundHandler, Remova
         data: Data,
         flags: UInt8 = 0
     ) async throws {
-        guard let channel else {
+        guard let channel, channel.isActive else {
             return
         }
         var buffer = channel.allocator.buffer(capacity: 8 + data.count)
         buffer.writeInteger(streamID & 0x7FFF_FFFF, endianness: .big)
         writeSPDYLength(flags: flags, length: data.count, to: &buffer)
         buffer.writeBytes(data)
-        try await channel.writeAndFlush(buffer).get()
+        do {
+            try await channel.writeAndFlush(buffer).get()
+        } catch {
+            await handleWriteFailure()
+            throw error
+        }
+    }
+
+    private func handleWriteFailure() async {
+        await cleanup(killProcess: true)
+        guard let channel else {
+            return
+        }
+        try? await channel.close().get()
     }
 }
 

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmExecutor.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmExecutor.swift
@@ -47,8 +47,9 @@ public struct MacOSKubeadmJoinRunner {
         } else {
             log.info("join completed")
             log.info("next: approve kubelet bootstrap CSR if your control plane does not auto-approve it")
-            let runtimeClassManifest = options.networkMode == .full ? "runtimeclass-macos.yaml" : "runtimeclass-macos-compat.yaml"
-            log.info("next: apply /usr/local/share/container-macos-node/manifests/\(runtimeClassManifest) from an admin workstation")
+            for profile in resolvedOptions.effectiveRuntimeClasses {
+                log.info("next: apply /usr/local/share/container-macos-node/manifests/\(profile.manifestFileName) from an admin workstation")
+            }
         }
     }
 

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmJoinOptions.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmJoinOptions.swift
@@ -51,6 +51,29 @@ public enum MacOSKubeadmNetworkMode: String, CaseIterable, Sendable, Equatable {
     }
 }
 
+public struct MacOSKubeadmRuntimeClassProfile: Sendable, Equatable {
+    public var name: String
+    public var handler: String
+    public var sandboxImage: String
+    public var networkMode: MacOSKubeadmNetworkMode
+
+    public init(
+        name: String,
+        handler: String? = nil,
+        sandboxImage: String,
+        networkMode: MacOSKubeadmNetworkMode
+    ) {
+        self.name = name
+        self.handler = handler ?? name
+        self.sandboxImage = sandboxImage
+        self.networkMode = networkMode
+    }
+
+    public var manifestFileName: String {
+        "runtimeclass-\(name).yaml"
+    }
+}
+
 public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
     public var apiServer: URL
     public var nodeName: String
@@ -62,6 +85,7 @@ public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
     public var clusterDNS: String
     public var clusterDomain: String
     public var sandboxImage: String
+    public var runtimeClasses: [MacOSKubeadmRuntimeClassProfile]
     public var networkMode: MacOSKubeadmNetworkMode
     public var containerServiceUserID: Int
     public var installRoot: String
@@ -80,6 +104,7 @@ public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
         clusterDNS: String = "10.96.0.10",
         clusterDomain: String = "cluster.local",
         sandboxImage: String = "localhost/macos-sandbox:latest",
+        runtimeClasses: [MacOSKubeadmRuntimeClassProfile] = [],
         networkMode: MacOSKubeadmNetworkMode = .full,
         containerServiceUserID: Int = 0,
         installRoot: String = "/",
@@ -97,6 +122,7 @@ public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
         self.clusterDNS = clusterDNS
         self.clusterDomain = clusterDomain
         self.sandboxImage = sandboxImage
+        self.runtimeClasses = runtimeClasses
         self.networkMode = networkMode
         self.containerServiceUserID = containerServiceUserID
         self.installRoot = installRoot
@@ -107,6 +133,19 @@ public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
 }
 
 extension MacOSKubeadmJoinOptions {
+    public var defaultRuntimeClass: MacOSKubeadmRuntimeClassProfile {
+        MacOSKubeadmRuntimeClassProfile(
+            name: networkMode.runtimeClassName,
+            handler: networkMode.runtimeHandler,
+            sandboxImage: sandboxImage,
+            networkMode: networkMode
+        )
+    }
+
+    public var effectiveRuntimeClasses: [MacOSKubeadmRuntimeClassProfile] {
+        [defaultRuntimeClass] + runtimeClasses
+    }
+
     public var rootPrefix: String {
         let trimmed = installRoot.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         if trimmed.isEmpty {

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmJoinOptions.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmJoinOptions.swift
@@ -63,6 +63,7 @@ public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
     public var clusterDomain: String
     public var sandboxImage: String
     public var networkMode: MacOSKubeadmNetworkMode
+    public var containerServiceUserID: Int
     public var installRoot: String
     public var startServices: Bool
     public var dryRun: Bool
@@ -80,6 +81,7 @@ public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
         clusterDomain: String = "cluster.local",
         sandboxImage: String = "localhost/macos-sandbox:latest",
         networkMode: MacOSKubeadmNetworkMode = .full,
+        containerServiceUserID: Int = 0,
         installRoot: String = "/",
         startServices: Bool = true,
         dryRun: Bool = false,
@@ -96,6 +98,7 @@ public struct MacOSKubeadmJoinOptions: Sendable, Equatable {
         self.clusterDomain = clusterDomain
         self.sandboxImage = sandboxImage
         self.networkMode = networkMode
+        self.containerServiceUserID = containerServiceUserID
         self.installRoot = installRoot
         self.startServices = startServices
         self.dryRun = dryRun

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmPlan.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmPlan.swift
@@ -111,6 +111,9 @@ public enum MacOSKubeadmPlanner {
                 action: .createDirectory(path: options.rooted(path), mode: 0o755)
             )
         }
+        if options.containerServiceUserID != 0 {
+            steps.append(contentsOf: kubeletPodsAccessSteps(options: options))
+        }
 
         steps.append(
             MacOSKubeadmStep(
@@ -492,6 +495,39 @@ public enum MacOSKubeadmPlanner {
             ),
         ])
         return steps
+    }
+
+    private static func kubeletPodsAccessSteps(options: MacOSKubeadmJoinOptions) -> [MacOSKubeadmStep] {
+        let podsPath = options.rooted("/var/lib/kubelet/pods")
+        let script = """
+            set -eu
+            user=$(/usr/bin/id -nu "$1")
+            path=$2
+            acl="$user allow read,readattr,readextattr,readsecurity,list,search,file_inherit,directory_inherit"
+            /bin/mkdir -p "$path"
+            /usr/bin/find "$path" -type d -exec /bin/chmod -a "$acl" {} + 2>/dev/null || true
+            /usr/bin/find "$path" -type d -exec /bin/chmod +a "$acl" {} +
+            """
+        return [
+            MacOSKubeadmStep(
+                message: "ensure directory /var/lib/kubelet/pods",
+                action: .createDirectory(path: podsPath, mode: 0o750)
+            ),
+            MacOSKubeadmStep(
+                message: "grant container service user access to kubelet pod directories",
+                action: .runCommand(
+                    arguments: [
+                        "/bin/sh",
+                        "-c",
+                        script,
+                        "container-macos-kubeadm-acl",
+                        "\(options.containerServiceUserID)",
+                        podsPath,
+                    ],
+                    bestEffort: false
+                )
+            ),
+        ]
     }
 
     private static func containerSystemCommand(userID: Int, subcommand: String) -> [String] {

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmPlan.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmPlan.swift
@@ -162,7 +162,8 @@ public enum MacOSKubeadmPlanner {
                     path: options.rooted("/etc/kubernetes/container-cri-shim-macos-config.json"),
                     contents: MacOSKubeadmRenderer.criShimConfiguration(
                         sandboxImage: options.sandboxImage,
-                        networkMode: options.networkMode
+                        networkMode: options.networkMode,
+                        runtimeClasses: options.runtimeClasses
                     ),
                     mode: 0o644,
                     sensitive: false
@@ -218,17 +219,19 @@ public enum MacOSKubeadmPlanner {
             ])
         }
 
-        let runtimeClassFile = options.networkMode == .full ? "runtimeclass-macos.yaml" : "runtimeclass-macos-compat.yaml"
-        steps.append(contentsOf: [
-            MacOSKubeadmStep(
-                message: "write RuntimeClass manifest",
-                action: .writeFile(
-                    path: options.rooted("/usr/local/share/container-macos-node/manifests/\(runtimeClassFile)"),
-                    contents: MacOSKubeadmRenderer.runtimeClassManifest(networkMode: options.networkMode),
-                    mode: 0o644,
-                    sensitive: false
+        steps.append(
+            contentsOf: options.effectiveRuntimeClasses.map { profile in
+                MacOSKubeadmStep(
+                    message: "write RuntimeClass manifest \(profile.name)",
+                    action: .writeFile(
+                        path: options.rooted("/usr/local/share/container-macos-node/manifests/\(profile.manifestFileName)"),
+                        contents: MacOSKubeadmRenderer.runtimeClassManifest(profile: profile),
+                        mode: 0o644,
+                        sensitive: false
+                    )
                 )
-            ),
+            })
+        steps.append(contentsOf: [
             MacOSKubeadmStep(
                 message: "write CRI shim launchd plist",
                 action: .writeFile(
@@ -377,6 +380,30 @@ public enum MacOSKubeadmPlanner {
         }
         if options.startServices && !options.rootPrefix.isEmpty && !options.dryRun {
             throw MacOSKubeadmError.invalidInput("--install-root cannot be combined with service start; pass --skip-start")
+        }
+        let runtimeClassNames = options.effectiveRuntimeClasses.map(\.name)
+        if Set(runtimeClassNames).count != runtimeClassNames.count {
+            throw MacOSKubeadmError.invalidInput("--runtime-class names must be unique")
+        }
+        let runtimeHandlers = options.effectiveRuntimeClasses.map(\.handler)
+        if Set(runtimeHandlers).count != runtimeHandlers.count {
+            throw MacOSKubeadmError.invalidInput("--runtime-class handlers must be unique")
+        }
+        for profile in options.effectiveRuntimeClasses {
+            try validateRuntimeClassProfile(profile)
+        }
+    }
+
+    private static func validateRuntimeClassProfile(_ profile: MacOSKubeadmRuntimeClassProfile) throws {
+        let dnsLabelPattern = #"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"#
+        guard profile.name.range(of: dnsLabelPattern, options: .regularExpression) != nil else {
+            throw MacOSKubeadmError.invalidInput("--runtime-class name must be a DNS label")
+        }
+        guard profile.handler.range(of: dnsLabelPattern, options: .regularExpression) != nil else {
+            throw MacOSKubeadmError.invalidInput("--runtime-class handler must be a DNS label")
+        }
+        guard !profile.sandboxImage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MacOSKubeadmError.invalidInput("--runtime-class sandbox image is required")
         }
     }
 

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmPlan.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmPlan.swift
@@ -230,7 +230,9 @@ public enum MacOSKubeadmPlanner {
                 message: "write CRI shim launchd plist",
                 action: .writeFile(
                     path: options.rooted("/Library/LaunchDaemons/com.apple.container.cri-shim-macos.plist"),
-                    contents: MacOSKubeadmRenderer.criShimPlist(),
+                    contents: MacOSKubeadmRenderer.criShimPlist(
+                        containerServiceUserID: options.containerServiceUserID
+                    ),
                     mode: 0o644,
                     sensitive: false
                 )
@@ -251,7 +253,11 @@ public enum MacOSKubeadmPlanner {
         ])
 
         if options.startServices {
-            steps.append(contentsOf: serviceStartSteps(networkMode: options.networkMode))
+            steps.append(
+                contentsOf: serviceStartSteps(
+                    networkMode: options.networkMode,
+                    containerServiceUserID: options.containerServiceUserID
+                ))
         }
 
         return MacOSKubeadmPlan(steps: steps)
@@ -357,6 +363,9 @@ public enum MacOSKubeadmPlanner {
         guard !options.networkMode.usesPodNetworking || !(options.kubeProxyToken ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw MacOSKubeadmError.invalidInput("discovered kube-proxy token is required")
         }
+        guard options.containerServiceUserID >= 0 else {
+            throw MacOSKubeadmError.invalidInput("--container-service-user must be a non-negative uid")
+        }
         guard !options.clusterDNS.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw MacOSKubeadmError.invalidInput("--cluster-dns is required")
         }
@@ -380,12 +389,22 @@ public enum MacOSKubeadmPlanner {
         }
     }
 
-    private static func serviceStartSteps(networkMode: MacOSKubeadmNetworkMode) -> [MacOSKubeadmStep] {
+    private static func serviceStartSteps(
+        networkMode: MacOSKubeadmNetworkMode,
+        containerServiceUserID: Int
+    ) -> [MacOSKubeadmStep] {
         var steps = [
+            MacOSKubeadmStep(
+                message: "stop container core services if present",
+                action: .runCommand(
+                    arguments: containerSystemCommand(userID: containerServiceUserID, subcommand: "stop"),
+                    bestEffort: true
+                )
+            ),
             MacOSKubeadmStep(
                 message: "start container core services",
                 action: .runCommand(
-                    arguments: ["/bin/launchctl", "asuser", "0", "/usr/local/bin/container", "system", "start"],
+                    arguments: containerSystemCommand(userID: containerServiceUserID, subcommand: "start"),
                     bestEffort: false
                 )
             ),
@@ -473,5 +492,12 @@ public enum MacOSKubeadmPlanner {
             ),
         ])
         return steps
+    }
+
+    private static func containerSystemCommand(userID: Int, subcommand: String) -> [String] {
+        if userID == 0 {
+            return ["/bin/launchctl", "asuser", "0", "/usr/local/bin/container", "system", subcommand]
+        }
+        return ["/usr/bin/sudo", "-u", "#\(userID)", "/usr/local/bin/container", "system", subcommand]
     }
 }

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
@@ -236,13 +236,13 @@ public enum MacOSKubeadmRenderer {
         return lines.joined(separator: "\n") + "\n"
     }
 
-    public static func criShimPlist() -> String {
+    public static func criShimPlist(containerServiceUserID: Int = 0) -> String {
         launchdPlist(
             label: "com.apple.container.cri-shim-macos",
             programArguments: [
                 "/bin/launchctl",
                 "asuser",
-                "0",
+                "\(containerServiceUserID)",
                 "/usr/local/bin/container-cri-shim-macos",
                 "--config",
                 "/etc/kubernetes/container-cri-shim-macos-config.json",

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
@@ -51,7 +51,7 @@ public enum MacOSKubeadmRenderer {
         """
         apiVersion: kubelet.config.k8s.io/v1beta1
         kind: KubeletConfiguration
-        address: "127.0.0.1"
+        address: "0.0.0.0"
         port: 10250
         readOnlyPort: 0
         staticPodPath: "/etc/kubernetes/manifests"

--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
@@ -88,8 +88,21 @@ public enum MacOSKubeadmRenderer {
 
     public static func criShimConfiguration(
         sandboxImage: String,
-        networkMode: MacOSKubeadmNetworkMode = .full
+        networkMode: MacOSKubeadmNetworkMode = .full,
+        runtimeClasses: [MacOSKubeadmRuntimeClassProfile] = []
     ) -> String {
+        let sandboxImageJSON = jsonString(sandboxImage)
+        let profiles =
+            [
+                MacOSKubeadmRuntimeClassProfile(
+                    name: networkMode.runtimeClassName,
+                    handler: networkMode.runtimeHandler,
+                    sandboxImage: sandboxImage,
+                    networkMode: networkMode
+                )
+            ] + runtimeClasses
+        let runtimeHandlers = profiles.map(runtimeHandlerJSON).joined(separator: ",\n")
+
         switch networkMode {
         case .full:
             return """
@@ -106,7 +119,7 @@ public enum MacOSKubeadmRenderer {
                         "plugin": "macvmnet"
                     },
                     "defaults": {
-                        "sandboxImage": "\(sandboxImage)",
+                        "sandboxImage": \(sandboxImageJSON),
                         "workloadPlatform": {
                             "os": "darwin",
                             "architecture": "arm64"
@@ -116,12 +129,7 @@ public enum MacOSKubeadmRenderer {
                         "guiEnabled": false
                     },
                     "runtimeHandlers": {
-                        "macos": {
-                            "sandboxImage": "\(sandboxImage)",
-                            "network": "default",
-                            "networkBackend": "vmnetShared",
-                            "guiEnabled": false
-                        }
+                \(runtimeHandlers)
                     },
                     "networkPolicy": {
                         "enabled": false
@@ -143,7 +151,7 @@ public enum MacOSKubeadmRenderer {
                         "port": 0
                     },
                     "defaults": {
-                        "sandboxImage": "\(sandboxImage)",
+                        "sandboxImage": \(sandboxImageJSON),
                         "workloadPlatform": {
                             "os": "darwin",
                             "architecture": "arm64"
@@ -153,12 +161,7 @@ public enum MacOSKubeadmRenderer {
                         "guiEnabled": false
                     },
                     "runtimeHandlers": {
-                        "macos-compat": {
-                            "sandboxImage": "\(sandboxImage)",
-                            "network": "default",
-                            "networkBackend": "virtualizationNAT",
-                            "guiEnabled": false
-                        }
+                \(runtimeHandlers)
                     },
                     "networkPolicy": {
                         "enabled": false
@@ -170,6 +173,22 @@ public enum MacOSKubeadmRenderer {
 
                 """
         }
+    }
+
+    private static func runtimeHandlerJSON(_ profile: MacOSKubeadmRuntimeClassProfile) -> String {
+        """
+                        \(jsonString(profile.handler)): {
+                            "sandboxImage": \(jsonString(profile.sandboxImage)),
+                            "network": "default",
+                            "networkBackend": \(jsonString(profile.networkMode.networkBackend)),
+                            "guiEnabled": false
+                        }
+        """
+    }
+
+    private static func jsonString(_ value: String) -> String {
+        let data = (try? JSONEncoder().encode(value)) ?? Data(#""""#.utf8)
+        return String(decoding: data, as: UTF8.self)
     }
 
     public static func cniConfiguration() -> String {
@@ -208,24 +227,34 @@ public enum MacOSKubeadmRenderer {
     }
 
     public static func runtimeClassManifest(networkMode: MacOSKubeadmNetworkMode = .full) -> String {
+        runtimeClassManifest(
+            profile: MacOSKubeadmRuntimeClassProfile(
+                name: networkMode.runtimeClassName,
+                handler: networkMode.runtimeHandler,
+                sandboxImage: "",
+                networkMode: networkMode
+            ))
+    }
+
+    public static func runtimeClassManifest(profile: MacOSKubeadmRuntimeClassProfile) -> String {
         var lines = [
             "apiVersion: node.k8s.io/v1",
             "kind: RuntimeClass",
             "metadata:",
-            "  name: \(networkMode.runtimeClassName)",
-            "handler: \(networkMode.runtimeHandler)",
+            "  name: \(profile.name)",
+            "handler: \(profile.handler)",
             "scheduling:",
             "  nodeSelector:",
             "    kubernetes.io/os: darwin",
             "    node.kubernetes.io/macos: \"true\"",
-            "    node.kubernetes.io/macos-network: \"\(networkMode.nodeNetworkLabelValue)\"",
+            "    node.kubernetes.io/macos-network: \"\(profile.networkMode.nodeNetworkLabelValue)\"",
             "  tolerations:",
             "    - key: node.kubernetes.io/macos",
             "      operator: Equal",
             "      value: \"true\"",
             "      effect: NoSchedule",
         ]
-        if networkMode == .compat {
+        if profile.networkMode == .compat {
             lines.append(contentsOf: [
                 "    - key: node.kubernetes.io/macos-network",
                 "      operator: Equal",

--- a/Sources/ContainerXPC/XPCServer.swift
+++ b/Sources/ContainerXPC/XPCServer.swift
@@ -159,12 +159,14 @@ public struct XPCServer: Sendable {
             return
         }
 
-        // Ensure that the client has our EUID
+        // Ensure that the client has our EUID. Root is allowed so system daemons
+        // can talk to per-user container services when macOS requires a GUI user
+        // bootstrap domain to start macOS guests.
         var token = audit_token_t()
         xpc_dictionary_get_audit_token(object, &token)
         let serverEuid = geteuid()
         let clientEuid = audit_token_to_euid(token)
-        guard clientEuid == serverEuid else {
+        guard Self.isAuthorizedClient(serverEuid: serverEuid, clientEuid: clientEuid) else {
             log.error(
                 "unauthorized request - uid mismatch",
                 metadata: [
@@ -226,6 +228,10 @@ public struct XPCServer: Sendable {
         let reply = message.reply()
         reply.set(error: err)
         xpc_connection_send_message(connection, reply.underlying)
+    }
+
+    public static func isAuthorizedClient(serverEuid: uid_t, clientEuid: uid_t) -> Bool {
+        clientEuid == serverEuid || clientEuid == 0
     }
 }
 

--- a/Sources/Helpers/MacOSGuestAgent/MacOSGuestAgent.swift
+++ b/Sources/Helpers/MacOSGuestAgent/MacOSGuestAgent.swift
@@ -868,6 +868,9 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
         connection: AgentConnection
     ) throws -> SpawnedProcessSession {
         let preparedExec = PreparedCStringArray([executable] + arguments)
+        let preparedExecutableSearch = PreparedCStringArray(
+            executableSearchCandidates(executable: executable, environment: environment)
+        )
         let preparedEnv = PreparedCStringArray(environment)
         let preparedWorkingDirectory = workingDirectory.map(PreparedCString.init)
 
@@ -908,7 +911,7 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
                 closeIfValid(masterFD)
                 runChild(
                     execStatusFD: execStatus.writeEnd,
-                    executable: preparedExec.pointer.pointee,
+                    executableSearch: preparedExecutableSearch.pointer,
                     arguments: preparedExec.pointer,
                     environment: preparedEnv.pointer,
                     workingDirectory: preparedWorkingDirectory?.pointer,
@@ -924,7 +927,7 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
                 closeIfValid(stderrPipe?.readEnd)
                 runChild(
                     execStatusFD: execStatus.writeEnd,
-                    executable: preparedExec.pointer.pointee,
+                    executableSearch: preparedExecutableSearch.pointer,
                     arguments: preparedExec.pointer,
                     environment: preparedEnv.pointer,
                     workingDirectory: preparedWorkingDirectory?.pointer,
@@ -1201,6 +1204,52 @@ private func readExecStatus(_ fd: Int32) throws -> Int32? {
     return code
 }
 
+private let defaultExecutableSearchPath = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+private func executableSearchCandidates(executable: String, environment: [String]) -> [String] {
+    guard !executable.contains("/") else {
+        return [executable]
+    }
+
+    let searchPath =
+        environment.first { $0.hasPrefix("PATH=") }.map { String($0.dropFirst(5)) }
+        ?? defaultExecutableSearchPath
+    if searchPath.isEmpty {
+        return ["./\(executable)"]
+    }
+
+    return searchPath.split(separator: ":", omittingEmptySubsequences: false).map { component in
+        let directory = component.isEmpty ? "." : String(component)
+        if directory.hasSuffix("/") {
+            return "\(directory)\(executable)"
+        }
+        return "\(directory)/\(executable)"
+    }
+}
+
+private func execWithPathSearch(
+    _ executableSearch: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+    arguments: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+    environment: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+) -> Int32 {
+    var index = 0
+    var permissionErrno: Int32?
+    while let candidate = executableSearch.advanced(by: index).pointee {
+        execve(candidate, arguments, environment)
+        let code = Int32(errno)
+        switch code {
+        case Int32(ENOENT), Int32(ENOTDIR):
+            break
+        case Int32(EACCES):
+            permissionErrno = code
+        default:
+            return code
+        }
+        index += 1
+    }
+    return permissionErrno ?? Int32(ENOENT)
+}
+
 private func wifexited(_ status: Int32) -> Bool {
     (status & 0x7f) == 0
 }
@@ -1220,7 +1269,7 @@ private func wtermsig(_ status: Int32) -> Int32 {
 
 private func runChild(
     execStatusFD: Int32,
-    executable: UnsafeMutablePointer<CChar>?,
+    executableSearch: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
     arguments: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
     environment: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
     workingDirectory: UnsafeMutablePointer<CChar>?,
@@ -1288,11 +1337,7 @@ private func runChild(
     if let workingDirectory, chdir(workingDirectory) != 0 {
         fail(Int32(errno))
     }
-    guard let executable else {
-        fail(Int32(EINVAL))
-    }
-    execve(executable, arguments, environment)
-    fail(Int32(errno))
+    fail(execWithPathSearch(executableSearch, arguments: arguments, environment: environment))
 }
 
 private func sendSignalToProcessTree(pid: pid_t, signal: Int32) throws {

--- a/Sources/Helpers/MacOSKubeadm/MacOSKubeadm.swift
+++ b/Sources/Helpers/MacOSKubeadm/MacOSKubeadm.swift
@@ -53,6 +53,9 @@ extension MacOSKubeadm {
         @Option(help: "macOS sandbox image used by CRI shim and kubelet.")
         var sandboxImage: String = "localhost/macos-sandbox:latest"
 
+        @Option(help: "Additional RuntimeClass in name=sandbox-image format. May be repeated; each entry uses the selected --network-mode.")
+        var runtimeClass: [String] = []
+
         @Option(help: "Node network mode: full or compat.")
         var networkMode: String = MacOSKubeadmNetworkMode.full.rawValue
 
@@ -75,6 +78,9 @@ extension MacOSKubeadm {
             let apiServer = try parseAPIServerEndpoint(apiServerEndpoint)
             let resolvedNetworkMode = try parseNetworkMode(networkMode)
             let resolvedContainerServiceUser = try resolveContainerServiceUser(networkMode: resolvedNetworkMode)
+            let resolvedRuntimeClasses = try runtimeClass.map {
+                try parseRuntimeClass($0, networkMode: resolvedNetworkMode)
+            }
 
             let options = MacOSKubeadmJoinOptions(
                 apiServer: apiServer,
@@ -82,6 +88,7 @@ extension MacOSKubeadm {
                 token: token,
                 discoveryTokenCACertHashes: discoveryTokenCACertHash,
                 sandboxImage: sandboxImage,
+                runtimeClasses: resolvedRuntimeClasses,
                 networkMode: resolvedNetworkMode,
                 containerServiceUserID: resolvedContainerServiceUser,
                 installRoot: installRoot,
@@ -114,6 +121,29 @@ extension MacOSKubeadm {
                 throw ValidationError("--network-mode must be one of: \(allowed)")
             }
             return mode
+        }
+
+        private func parseRuntimeClass(
+            _ value: String,
+            networkMode: MacOSKubeadmNetworkMode
+        ) throws -> MacOSKubeadmRuntimeClassProfile {
+            let parts = value.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else {
+                throw ValidationError("--runtime-class must use name=sandbox-image")
+            }
+            let name = String(parts[0]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let image = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else {
+                throw ValidationError("--runtime-class name is required")
+            }
+            guard !image.isEmpty else {
+                throw ValidationError("--runtime-class sandbox image is required")
+            }
+            return MacOSKubeadmRuntimeClassProfile(
+                name: name,
+                sandboxImage: image,
+                networkMode: networkMode
+            )
         }
 
         private func resolveContainerServiceUser(networkMode: MacOSKubeadmNetworkMode) throws -> Int {

--- a/Sources/Helpers/MacOSKubeadm/MacOSKubeadm.swift
+++ b/Sources/Helpers/MacOSKubeadm/MacOSKubeadm.swift
@@ -56,6 +56,9 @@ extension MacOSKubeadm {
         @Option(help: "Node network mode: full or compat.")
         var networkMode: String = MacOSKubeadmNetworkMode.full.rawValue
 
+        @Option(help: "UID whose bootstrap domain runs container core services. Defaults to SUDO_UID for compat joins, otherwise 0.")
+        var containerServiceUser: Int?
+
         @Option(help: "Alternate filesystem root for tests and image assembly. Normal deployments use '/'.")
         var installRoot: String = "/"
 
@@ -71,6 +74,7 @@ extension MacOSKubeadm {
         func run() throws {
             let apiServer = try parseAPIServerEndpoint(apiServerEndpoint)
             let resolvedNetworkMode = try parseNetworkMode(networkMode)
+            let resolvedContainerServiceUser = try resolveContainerServiceUser(networkMode: resolvedNetworkMode)
 
             let options = MacOSKubeadmJoinOptions(
                 apiServer: apiServer,
@@ -79,6 +83,7 @@ extension MacOSKubeadm {
                 discoveryTokenCACertHashes: discoveryTokenCACertHash,
                 sandboxImage: sandboxImage,
                 networkMode: resolvedNetworkMode,
+                containerServiceUserID: resolvedContainerServiceUser,
                 installRoot: installRoot,
                 startServices: !skipStart,
                 dryRun: dryRun,
@@ -109,6 +114,25 @@ extension MacOSKubeadm {
                 throw ValidationError("--network-mode must be one of: \(allowed)")
             }
             return mode
+        }
+
+        private func resolveContainerServiceUser(networkMode: MacOSKubeadmNetworkMode) throws -> Int {
+            if let containerServiceUser {
+                guard containerServiceUser >= 0 else {
+                    throw ValidationError("--container-service-user must be a non-negative uid")
+                }
+                return containerServiceUser
+            }
+            guard networkMode == .compat else {
+                return 0
+            }
+            guard let sudoUID = ProcessInfo.processInfo.environment["SUDO_UID"],
+                let uid = Int(sudoUID),
+                uid > 0
+            else {
+                return 0
+            }
+            return uid
         }
     }
 

--- a/Sources/Helpers/RuntimeMacOSSidecar/RuntimeMacOSSidecar.swift
+++ b/Sources/Helpers/RuntimeMacOSSidecar/RuntimeMacOSSidecar.swift
@@ -1591,6 +1591,10 @@ final class SidecarControlServer: @unchecked Sendable {
         try waitForProcessStartAck(fd: fd, expectedProcessID: expectedProcessID, timeoutSeconds: timeoutSeconds)
     }
 
+    func _testGuestExecutableLaunch(executable: String, arguments: [String]) -> (executable: String, arguments: [String]) {
+        guestExecutableLaunch(executable: executable, arguments: arguments)
+    }
+
     private func sendFrame(_ frame: SidecarGuestAgentFrame, to session: ProcessStreamSession) throws {
         session.writeLock.lock()
         defer { session.writeLock.unlock() }
@@ -1810,11 +1814,12 @@ final class SidecarControlServer: @unchecked Sendable {
             try waitForGuestAgentReadyWithTimeout(fd: fd, timeoutSeconds: 3)
             let env = exec.environment ?? ["PATH=/usr/bin:/bin:/usr/sbin:/sbin"]
             let cwd = exec.workingDirectory ?? "/"
+            let launch = guestExecutableLaunch(executable: exec.executable, arguments: exec.arguments)
             try MacOSSidecarSocketIO.writeJSONFrame(
                 SidecarGuestAgentFrame.exec(
                     id: processID,
-                    executable: exec.executable,
-                    arguments: exec.arguments,
+                    executable: launch.executable,
+                    arguments: launch.arguments,
                     environment: env,
                     rootDirectory: exec.rootDirectory,
                     workingDirectory: cwd,
@@ -1835,6 +1840,13 @@ final class SidecarControlServer: @unchecked Sendable {
             Darwin.close(fd)
             throw error
         }
+    }
+
+    private func guestExecutableLaunch(executable: String, arguments: [String]) -> (executable: String, arguments: [String]) {
+        guard !executable.isEmpty, !executable.contains("/") else {
+            return (executable, arguments)
+        }
+        return ("/usr/bin/env", [executable] + arguments)
     }
 
     private func startProcessReadLoop(_ session: ProcessStreamSession, initialFrames: [SidecarGuestAgentFrame] = []) {

--- a/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
+++ b/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
@@ -797,6 +797,120 @@ struct CRIShimRuntimeServerTests {
     }
 
     @Test
+    func stopPodSandboxTreatsMissingWorkloadOptionsAsAlreadyStopped() async throws {
+        let socketPath = "/tmp/cri-shim-stop-missing-options-\(UUID().uuidString.prefix(8)).sock"
+        let stateDirectory = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: stateDirectory) }
+
+        let config = CRIShimConfig(
+            runtimeEndpoint: "/var/run/container-cri-macos.sock",
+            stateDirectory: stateDirectory.path,
+            streaming: StreamingConfig(address: "127.0.0.1", port: 0),
+            defaults: RuntimeProfile(
+                sandboxImage: "localhost/macos-sandbox:latest",
+                workloadPlatform: WorkloadPlatform(os: "darwin", architecture: "arm64"),
+                network: "default",
+                networkBackend: "virtualizationNAT",
+                guiEnabled: false
+            ),
+            runtimeHandlers: [
+                "macos-compat": RuntimeProfile(networkBackend: "virtualizationNAT")
+            ],
+            networkPolicy: NetworkPolicyConfig(enabled: false),
+            kubeProxy: KubeProxyConfig(enabled: false)
+        )
+        let metadataStore = try CRIShimMetadataStore(rootURL: stateDirectory)
+        try metadataStore.upsertSandbox(
+            CRIShimSandboxMetadata(
+                id: "sandbox-1",
+                podUID: "pod-uid",
+                namespace: "default",
+                name: "stop-missing-options",
+                attempt: 1,
+                runtimeHandler: "macos-compat",
+                sandboxImage: "localhost/macos-sandbox:latest",
+                state: .running,
+                createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+                updatedAt: Date(timeIntervalSince1970: 1_700_000_100)
+            ))
+        try metadataStore.upsertContainer(
+            CRIShimContainerMetadata(
+                id: "container-1",
+                sandboxID: "sandbox-1",
+                name: "workload",
+                attempt: 1,
+                image: "example.com/macos/workload:latest",
+                runtimeHandler: "macos-compat",
+                command: ["/bin/true"],
+                args: [],
+                logPath: stateDirectory.appendingPathComponent("workload/0.log").path,
+                state: .running,
+                createdAt: Date(timeIntervalSince1970: 1_700_000_010),
+                startedAt: Date(timeIntervalSince1970: 1_700_000_020)
+            ))
+
+        let runtimeManager = RecordingRuntimeManager(
+            execSyncResult: ExecSyncResult(exitCode: 0, stdout: Data(), stderr: Data())
+        )
+        runtimeManager.stopWorkloadError = ContainerizationError(
+            .internalError,
+            message: "failed to stop workload in sandbox",
+            cause: OpaqueCRIShimError(
+                description:
+                    #"unknown: "Error Domain=NSCocoaErrorDomain Code=260 "options.json missing" UserInfo={NSFilePath=/Users/bytedance/Library/Application Support/com.apple.container/containers/container-1/options.json, NSUnderlyingError=0x1 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}"#
+            )
+        )
+        let imageManager = RecordingImageManager(images: [])
+        let cniManager = RecordingCNIManager()
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let server = CRIShimGRPCServer(
+            socketPath: socketPath,
+            serviceProviders: [
+                CRIShimRuntimeServiceProvider(
+                    config: config,
+                    metadataStore: metadataStore,
+                    runtimeManager: runtimeManager,
+                    imageManager: imageManager,
+                    cniManager: cniManager
+                ),
+                CRIShimImageServiceProvider(imageManager: imageManager),
+            ],
+            eventLoopGroup: group,
+            startupTasks: []
+        )
+        let serverTask = Task {
+            try await server.run()
+        }
+        defer {
+            serverTask.cancel()
+            _ = try? FileManager.default.removeItem(atPath: socketPath)
+        }
+
+        try await waitForSocket(at: socketPath)
+
+        let channel = ClientConnection.insecure(group: group)
+            .withConnectedSocket(try connectedUnixSocket(path: socketPath))
+        let client = Runtime_V1_RuntimeServiceAsyncClient(channel: channel)
+
+        var stopRequest = Runtime_V1_StopPodSandboxRequest()
+        stopRequest.podSandboxID = "sandbox-1"
+        _ = try await client.stopPodSandbox(stopRequest)
+
+        #expect(runtimeManager.stopWorkloadCalls.count == 1)
+        #expect(runtimeManager.stopSandboxCalls.count == 1)
+        #expect(cniManager.deleteCalls.isEmpty)
+        let container = try #require(try metadataStore.container(id: "container-1"))
+        #expect(container.state == .exited)
+        let sandbox = try #require(try metadataStore.sandbox(id: "sandbox-1"))
+        #expect(sandbox.state == .stopped)
+
+        try await channel.close().get()
+        await server.stop()
+        try await serverTask.value
+        await shutdown(group)
+    }
+
+    @Test
     func runPodSandboxPullsSandboxImageWhenMissing() async throws {
         let socketPath = "/tmp/cri-shim-sandbox-pull-\(UUID().uuidString.prefix(8)).sock"
         let stateDirectory = makeTemporaryDirectory()

--- a/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
+++ b/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
@@ -1012,6 +1012,124 @@ struct CRIShimRuntimeServerTests {
     }
 
     @Test
+    func runPodSandboxAnnotationOverridesSandboxImage() async throws {
+        let socketPath = "/tmp/cri-shim-sandbox-annotation-\(UUID().uuidString.prefix(8)).sock"
+        let stateDirectory = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: stateDirectory) }
+
+        let handlerImageReference = "ghcr.io/jianliang00/macos-base:15.2"
+        let overrideImageReference = "ghcr.io/jianliang00/macos-base:15.4"
+        let config = CRIShimConfig(
+            runtimeEndpoint: "/var/run/container-cri-macos.sock",
+            stateDirectory: stateDirectory.path,
+            streaming: StreamingConfig(address: "127.0.0.1", port: 0),
+            defaults: RuntimeProfile(
+                sandboxImage: "localhost/macos-sandbox:latest",
+                workloadPlatform: WorkloadPlatform(os: "darwin", architecture: "arm64"),
+                network: "default",
+                networkBackend: "virtualizationNAT",
+                guiEnabled: false
+            ),
+            runtimeHandlers: [
+                "macos-15-2": RuntimeProfile(
+                    sandboxImage: handlerImageReference,
+                    networkBackend: "virtualizationNAT"
+                )
+            ],
+            networkPolicy: NetworkPolicyConfig(enabled: false),
+            kubeProxy: KubeProxyConfig(enabled: false)
+        )
+        let runtimeManager = RecordingRuntimeManager(
+            execSyncResult: ExecSyncResult(exitCode: 0, stdout: Data(), stderr: Data())
+        )
+        let imageManager = RecordingImageManager(images: [
+            CRIShimImageRecord(
+                reference: overrideImageReference,
+                digest: "sha256:sandbox-154",
+                size: 16_384,
+                annotations: ["org.apple.container.macos.image.role": "sandbox"]
+            )
+        ])
+        let cniManager = RecordingCNIManager()
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let server = try CRIShimGRPCServer(
+            socketPath: socketPath,
+            config: config,
+            versionInfo: CRIShimRuntimeVersionInfo(),
+            eventLoopGroup: group,
+            readinessChecker: StaticReadinessChecker(
+                snapshot: CRIShimReadinessSnapshot(
+                    runtime: CRIShimRuntimeConditionSnapshot(
+                        type: CRIShimRuntimeConditionType.runtimeReady,
+                        status: true,
+                        reason: "RuntimeHealthOK",
+                        message: "test runtime ready"
+                    ),
+                    network: CRIShimRuntimeConditionSnapshot(
+                        type: CRIShimRuntimeConditionType.networkReady,
+                        status: true,
+                        reason: "NATReady",
+                        message: "test network ready"
+                    )
+                )
+            ),
+            runtimeManager: runtimeManager,
+            imageManager: imageManager,
+            cniManager: cniManager
+        )
+        let serverTask = Task {
+            try await server.run()
+        }
+        defer {
+            serverTask.cancel()
+            _ = try? FileManager.default.removeItem(atPath: socketPath)
+        }
+
+        try await waitForSocket(at: socketPath)
+
+        let channel = ClientConnection.insecure(group: group)
+            .withConnectedSocket(try connectedUnixSocket(path: socketPath))
+        let client = Runtime_V1_RuntimeServiceAsyncClient(channel: channel)
+
+        var runSandboxRequest = Runtime_V1_RunPodSandboxRequest()
+        runSandboxRequest.runtimeHandler = "macos-15-2"
+        runSandboxRequest.config.metadata.uid = "override-pod-uid"
+        runSandboxRequest.config.metadata.namespace = "default"
+        runSandboxRequest.config.metadata.name = "override-pod"
+        runSandboxRequest.config.metadata.attempt = 1
+        runSandboxRequest.config.annotations = [
+            CRIShimPodAnnotation.sandboxImage: overrideImageReference
+        ]
+        let runSandbox = try await client.runPodSandbox(runSandboxRequest)
+
+        #expect(!runSandbox.podSandboxID.isEmpty)
+        #expect(imageManager.pulledReferences.isEmpty)
+        #expect(runtimeManager.createSandboxCalls.count == 1)
+        let createSandboxCall = try #require(runtimeManager.createSandboxCalls.first)
+        #expect(createSandboxCall.image.reference == overrideImageReference)
+        #expect(createSandboxCall.image.digest == "sha256:sandbox-154")
+        #expect(createSandboxCall.networks.isEmpty)
+        #expect(cniManager.addCalls.isEmpty)
+
+        var statusRequest = Runtime_V1_PodSandboxStatusRequest()
+        statusRequest.podSandboxID = runSandbox.podSandboxID
+        statusRequest.verbose = true
+        let status = try await client.podSandboxStatus(statusRequest)
+        let metadataInfo = try #require(status.info["metadata"])
+        let metadata = try JSONDecoder.criShimMetadataDecoder.decode(
+            CRIShimSandboxMetadata.self,
+            from: Data(metadataInfo.utf8)
+        )
+        #expect(metadata.runtimeHandler == "macos-15-2")
+        #expect(metadata.sandboxImage == overrideImageReference)
+
+        try await channel.close().get()
+        await server.stop()
+        try await serverTask.value
+        await shutdown(group)
+    }
+
+    @Test
     func execStreamingTimeoutKillsIdleProcess() async throws {
         let socketPath = "/tmp/cri-shim-timeout-\(UUID().uuidString.prefix(8)).sock"
         let stateDirectory = makeTemporaryDirectory()

--- a/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
+++ b/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
@@ -797,6 +797,107 @@ struct CRIShimRuntimeServerTests {
     }
 
     @Test
+    func runPodSandboxPullsSandboxImageWhenMissing() async throws {
+        let socketPath = "/tmp/cri-shim-sandbox-pull-\(UUID().uuidString.prefix(8)).sock"
+        let stateDirectory = makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: stateDirectory) }
+
+        let sandboxImageReference = "ghcr.io/jianliang00/macos-base:15.2"
+        let config = CRIShimConfig(
+            runtimeEndpoint: "/var/run/container-cri-macos.sock",
+            stateDirectory: stateDirectory.path,
+            streaming: StreamingConfig(address: "127.0.0.1", port: 0),
+            defaults: RuntimeProfile(
+                sandboxImage: sandboxImageReference,
+                workloadPlatform: WorkloadPlatform(os: "darwin", architecture: "arm64"),
+                network: "default",
+                networkBackend: "virtualizationNAT",
+                guiEnabled: false
+            ),
+            runtimeHandlers: [
+                "macos-compat": RuntimeProfile(networkBackend: "virtualizationNAT")
+            ],
+            networkPolicy: NetworkPolicyConfig(enabled: false),
+            kubeProxy: KubeProxyConfig(enabled: false)
+        )
+        let runtimeManager = RecordingRuntimeManager(
+            execSyncResult: ExecSyncResult(exitCode: 0, stdout: Data(), stderr: Data())
+        )
+        let imageManager = RecordingImageManager(
+            images: [],
+            pulledImage: CRIShimImageRecord(
+                reference: sandboxImageReference,
+                digest: "sha256:sandbox",
+                size: 16_384,
+                annotations: ["org.apple.container.macos.image.role": "sandbox"]
+            )
+        )
+        let cniManager = RecordingCNIManager()
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let server = try CRIShimGRPCServer(
+            socketPath: socketPath,
+            config: config,
+            versionInfo: CRIShimRuntimeVersionInfo(),
+            eventLoopGroup: group,
+            readinessChecker: StaticReadinessChecker(
+                snapshot: CRIShimReadinessSnapshot(
+                    runtime: CRIShimRuntimeConditionSnapshot(
+                        type: CRIShimRuntimeConditionType.runtimeReady,
+                        status: true,
+                        reason: "RuntimeHealthOK",
+                        message: "test runtime ready"
+                    ),
+                    network: CRIShimRuntimeConditionSnapshot(
+                        type: CRIShimRuntimeConditionType.networkReady,
+                        status: true,
+                        reason: "NATReady",
+                        message: "test network ready"
+                    )
+                )
+            ),
+            runtimeManager: runtimeManager,
+            imageManager: imageManager,
+            cniManager: cniManager
+        )
+        let serverTask = Task {
+            try await server.run()
+        }
+        defer {
+            serverTask.cancel()
+            _ = try? FileManager.default.removeItem(atPath: socketPath)
+        }
+
+        try await waitForSocket(at: socketPath)
+
+        let channel = ClientConnection.insecure(group: group)
+            .withConnectedSocket(try connectedUnixSocket(path: socketPath))
+        let client = Runtime_V1_RuntimeServiceAsyncClient(channel: channel)
+
+        var runSandboxRequest = Runtime_V1_RunPodSandboxRequest()
+        runSandboxRequest.runtimeHandler = "macos-compat"
+        runSandboxRequest.config.metadata.uid = "pull-pod-uid"
+        runSandboxRequest.config.metadata.namespace = "default"
+        runSandboxRequest.config.metadata.name = "pull-pod"
+        runSandboxRequest.config.metadata.attempt = 1
+        let runSandbox = try await client.runPodSandbox(runSandboxRequest)
+
+        #expect(!runSandbox.podSandboxID.isEmpty)
+        #expect(imageManager.pulledReferences == [sandboxImageReference])
+        #expect(imageManager.pulledAuthentications == [nil])
+        #expect(runtimeManager.createSandboxCalls.count == 1)
+        let createSandboxCall = try #require(runtimeManager.createSandboxCalls.first)
+        #expect(createSandboxCall.image.reference == sandboxImageReference)
+        #expect(createSandboxCall.image.digest == "sha256:sandbox")
+        #expect(createSandboxCall.networks.isEmpty)
+        #expect(cniManager.addCalls.isEmpty)
+
+        try await channel.close().get()
+        await server.stop()
+        try await serverTask.value
+        await shutdown(group)
+    }
+
+    @Test
     func execStreamingTimeoutKillsIdleProcess() async throws {
         let socketPath = "/tmp/cri-shim-timeout-\(UUID().uuidString.prefix(8)).sock"
         let stateDirectory = makeTemporaryDirectory()

--- a/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
+++ b/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
@@ -401,7 +401,7 @@ struct CRIShimRuntimeServerTests {
         #expect(runtimeManager.stopSandboxCalls.count == 1)
         let stopSandboxCall = try #require(runtimeManager.stopSandboxCalls.first)
         #expect(stopSandboxCall.id == runSandbox.podSandboxID)
-        #expect(stopSandboxCall.options.timeoutInSeconds == 5)
+        #expect(stopSandboxCall.options.timeoutInSeconds == 30)
         #expect(cniManager.deleteCalls.count == 1)
         let cniDeleteCall = try #require(cniManager.deleteCalls.first)
         #expect(cniDeleteCall.sandboxID == runSandbox.podSandboxID)

--- a/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
+++ b/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
@@ -278,6 +278,33 @@ struct MacOSKubeadmPlanTests {
                     && contents.contains("<string>501</string>")
                     && contents.contains("<string>/usr/local/bin/container-cri-shim-macos</string>")
             })
+
+        #expect(
+            plan.steps.contains { step in
+                guard step.message == "ensure directory /var/lib/kubelet/pods",
+                    case .createDirectory(let path, 0o750) = step.action
+                else {
+                    return false
+                }
+                return path == "/tmp/macos-node/var/lib/kubelet/pods"
+            })
+
+        #expect(
+            plan.steps.contains { step in
+                guard step.message == "grant container service user access to kubelet pod directories",
+                    case .runCommand(let arguments, false) = step.action
+                else {
+                    return false
+                }
+                return arguments.count == 6
+                    && arguments[0] == "/bin/sh"
+                    && arguments[1] == "-c"
+                    && arguments[2].contains("/usr/bin/id -nu")
+                    && arguments[2].contains("/bin/chmod +a")
+                    && arguments[3] == "container-macos-kubeadm-acl"
+                    && arguments[4] == "501"
+                    && arguments[5] == "/tmp/macos-node/var/lib/kubelet/pods"
+            })
     }
 
     @Test func joinPlanRequiresDiscoveryHash() throws {

--- a/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
+++ b/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
@@ -144,6 +144,75 @@ struct MacOSKubeadmPlanTests {
             })
     }
 
+    @Test func joinPlanRendersAdditionalRuntimeClasses() throws {
+        var options = try makeOptions(startServices: false)
+        options.networkMode = .compat
+        options.kubeProxyToken = nil
+        options.runtimeClasses = [
+            MacOSKubeadmRuntimeClassProfile(
+                name: "macos-15-2",
+                sandboxImage: "ghcr.io/jianliang00/macos-base:15.2",
+                networkMode: .compat
+            ),
+            MacOSKubeadmRuntimeClassProfile(
+                name: "macos-15-4",
+                sandboxImage: "ghcr.io/jianliang00/macos-base:15.4",
+                networkMode: .compat
+            ),
+        ]
+
+        let plan = try MacOSKubeadmPlanner.joinPlan(options: options)
+        let writes = plan.steps.compactMap { step -> (path: String, contents: String)? in
+            guard case .writeFile(let path, let contents, _, _) = step.action else {
+                return nil
+            }
+            return (path, contents)
+        }
+
+        let config = try #require(
+            writes.first { $0.path == "/tmp/macos-node/etc/kubernetes/container-cri-shim-macos-config.json" }?.contents
+        )
+        #expect(config.contains(#""macos-compat": {"#))
+        #expect(config.contains(#""macos-15-2": {"#))
+        #expect(config.contains(#""sandboxImage": "ghcr.io/jianliang00/macos-base:15.2""#))
+        #expect(config.contains(#""macos-15-4": {"#))
+        #expect(config.contains(#""sandboxImage": "ghcr.io/jianliang00/macos-base:15.4""#))
+        #expect(config.contains(#""networkBackend": "virtualizationNAT""#))
+
+        let runtimeClass15_2 = try #require(
+            writes.first {
+                $0.path == "/tmp/macos-node/usr/local/share/container-macos-node/manifests/runtimeclass-macos-15-2.yaml"
+            }?.contents
+        )
+        #expect(runtimeClass15_2.contains("name: macos-15-2"))
+        #expect(runtimeClass15_2.contains("handler: macos-15-2"))
+        #expect(runtimeClass15_2.contains("node.kubernetes.io/macos-network: \"compat\""))
+
+        let runtimeClass15_4 = try #require(
+            writes.first {
+                $0.path == "/tmp/macos-node/usr/local/share/container-macos-node/manifests/runtimeclass-macos-15-4.yaml"
+            }?.contents
+        )
+        #expect(runtimeClass15_4.contains("name: macos-15-4"))
+        #expect(runtimeClass15_4.contains("handler: macos-15-4"))
+        #expect(runtimeClass15_4.contains("node.kubernetes.io/macos-network: \"compat\""))
+    }
+
+    @Test func joinPlanRejectsDuplicateRuntimeClassNames() throws {
+        var options = try makeOptions(startServices: false)
+        options.runtimeClasses = [
+            MacOSKubeadmRuntimeClassProfile(
+                name: "macos",
+                sandboxImage: "ghcr.io/jianliang00/macos-base:26.3",
+                networkMode: .full
+            )
+        ]
+
+        #expect(throws: MacOSKubeadmError.invalidInput("--runtime-class names must be unique")) {
+            try MacOSKubeadmPlanner.joinPlan(options: options)
+        }
+    }
+
     @Test func kubeconfigsAreMarkedSensitive() throws {
         let options = try makeOptions(startServices: false)
         let plan = try MacOSKubeadmPlanner.joinPlan(options: options)

--- a/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
+++ b/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
@@ -244,6 +244,42 @@ struct MacOSKubeadmPlanTests {
             })
     }
 
+    @Test func serviceStartPlanCanUseNonRootContainerServiceUser() throws {
+        var options = try makeOptions(startServices: true)
+        options.containerServiceUserID = 501
+
+        let plan = try MacOSKubeadmPlanner.joinPlan(options: options)
+
+        #expect(
+            plan.steps.contains { step in
+                guard step.message == "start container core services",
+                    case .runCommand(let arguments, false) = step.action
+                else {
+                    return false
+                }
+                return arguments == [
+                    "/usr/bin/sudo",
+                    "-u",
+                    "#501",
+                    "/usr/local/bin/container",
+                    "system",
+                    "start",
+                ]
+            })
+
+        #expect(
+            plan.steps.contains { step in
+                guard step.message == "write CRI shim launchd plist",
+                    case .writeFile(_, let contents, 0o644, false) = step.action
+                else {
+                    return false
+                }
+                return contents.contains("<string>asuser</string>")
+                    && contents.contains("<string>501</string>")
+                    && contents.contains("<string>/usr/local/bin/container-cri-shim-macos</string>")
+            })
+    }
+
     @Test func joinPlanRequiresDiscoveryHash() throws {
         var options = try makeOptions(startServices: false)
         options.discoveryTokenCACertHashes = []

--- a/Tests/ContainerXPCTests/XPCServerAuthorizationTests.swift
+++ b/Tests/ContainerXPCTests/XPCServerAuthorizationTests.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerXPC
+import Testing
+
+struct XPCServerAuthorizationTests {
+    @Test func authorizesMatchingUserAndRootClients() {
+        #expect(XPCServer.isAuthorizedClient(serverEuid: uid_t(501), clientEuid: uid_t(501)))
+        #expect(XPCServer.isAuthorizedClient(serverEuid: uid_t(501), clientEuid: uid_t(0)))
+        #expect(!XPCServer.isAuthorizedClient(serverEuid: uid_t(501), clientEuid: uid_t(502)))
+    }
+}

--- a/Tests/MacOSGuestAgentTests/GuestAgentProcessStartupTests.swift
+++ b/Tests/MacOSGuestAgentTests/GuestAgentProcessStartupTests.swift
@@ -113,6 +113,48 @@ struct GuestAgentProcessStartupTests {
     }
 
     @Test
+    func executableNameSearchesPathEnvironment() throws {
+        signal(SIGPIPE, SIG_IGN)
+
+        let harness = try AgentConnectionHarness()
+        defer { harness.closePeer() }
+
+        let ready = try readAgentFrame(from: harness.peerFD)
+        #expect(ready.type == .ready)
+
+        try MacOSSidecarSocketIO.writeJSONFrame(
+            GuestAgentFrame(
+                type: .exec,
+                id: "path-search",
+                executable: "sh",
+                arguments: ["-c", "printf path-search-ok"],
+                environment: ["PATH=/bin:/usr/bin"],
+                workingDirectory: "/",
+                terminal: false,
+                uid: UInt32(geteuid()),
+                gid: UInt32(getegid())
+            ),
+            fd: harness.peerFD
+        )
+
+        var frames: [GuestAgentFrame] = []
+        for _ in 0..<8 {
+            let frame = try readAgentFrame(from: harness.peerFD)
+            frames.append(frame)
+            if frames.contains(where: { $0.type == .ack }) && frames.contains(where: { $0.type == .exit }) {
+                break
+            }
+        }
+
+        #expect(frames.contains(where: { $0.type == .ack && $0.id == "path-search" }))
+        #expect(frames.contains(where: { $0.type == .stdout && $0.data == Data("path-search-ok".utf8) }))
+        #expect(frames.contains(where: { $0.type == .exit && $0.exitCode == 0 }))
+        #expect(!frames.contains(where: { $0.type == .error }))
+
+        try harness.waitForCompletion()
+    }
+
+    @Test
     func fastProcessSendsAckBeforeExit() throws {
         signal(SIGPIPE, SIG_IGN)
 

--- a/Tests/RuntimeMacOSSidecarTests/SidecarControlServerTests.swift
+++ b/Tests/RuntimeMacOSSidecarTests/SidecarControlServerTests.swift
@@ -178,6 +178,42 @@ struct SidecarControlServerTests {
             #expect(String(describing: error).contains("No such file or directory"))
         }
     }
+
+    @Test
+    func bareExecutableLaunchUsesGuestPathLookup() throws {
+        let server = makeServer()
+
+        let launch = server._testGuestExecutableLaunch(
+            executable: "sh",
+            arguments: ["-lc", "echo ok"]
+        )
+
+        #expect(launch.executable == "/usr/bin/env")
+        #expect(launch.arguments == ["sh", "-lc", "echo ok"])
+    }
+
+    @Test
+    func pathExecutableLaunchIsPreserved() throws {
+        let server = makeServer()
+
+        let launch = server._testGuestExecutableLaunch(
+            executable: "/bin/sh",
+            arguments: ["-lc", "echo ok"]
+        )
+
+        #expect(launch.executable == "/bin/sh")
+        #expect(launch.arguments == ["-lc", "echo ok"])
+    }
+
+    @Test
+    func emptyExecutableLaunchIsPreserved() throws {
+        let server = makeServer()
+
+        let launch = server._testGuestExecutableLaunch(executable: "", arguments: ["arg"])
+
+        #expect(launch.executable == "")
+        #expect(launch.arguments == ["arg"])
+    }
 }
 
 private func makeServer() -> SidecarControlServer {

--- a/docs/macos-guest-k8s-cri-cni-implementation-plan.md
+++ b/docs/macos-guest-k8s-cri-cni-implementation-plan.md
@@ -668,15 +668,14 @@ Because this is an experimental macOS node path, workloads must opt in.
 Operator-facing manifests and examples are maintained in
 [`macos-guest-k8s-operator-guide.md`](./macos-guest-k8s-operator-guide.md).
 
-Recommended node setup:
-
-- label: `apple.com/macos-container=true`
-- label: `kubernetes.io/os=darwin`
-- taint: `apple.com/macos-container=true:NoSchedule`
-- `RuntimeClass` handler: `macos`
-- Pod `nodeSelector` or RuntimeClass scheduling rules selecting the macOS node,
-  including `kubernetes.io/os=darwin`
-- matching toleration for the macOS node taint
+`container-macos-kubeadm join` registers the node labels and taints for the
+selected network mode. Full-mode nodes use the `macos` RuntimeClass and
+`node.kubernetes.io/macos-network=full`; compat-mode nodes use the
+`macos-compat` RuntimeClass and `node.kubernetes.io/macos-network=compat`.
+RuntimeClass scheduling rules select the macOS node with
+`kubernetes.io/os=darwin`, `node.kubernetes.io/macos=true`, and the matching
+network-mode label, then provide the required tolerations for the macOS node
+taints.
 
 Pod manifests should omit `.spec.os.name` unless the deployed Kubernetes API
 server and kubelet explicitly admit `darwin` as a Pod OS value. The supported

--- a/docs/macos-guest-k8s-operator-guide.md
+++ b/docs/macos-guest-k8s-operator-guide.md
@@ -121,6 +121,52 @@ signals are:
 - the macOS node taint and matching toleration supplied by RuntimeClass
   scheduling
 
+## Sandbox Image Selection
+
+The default RuntimeClass for a joined node uses the sandbox image configured
+with `container-macos-kubeadm join --sandbox-image`.
+
+Operators can expose additional administrator-defined sandbox images by
+repeating `--runtime-class <name>=<sandbox-image>` during join:
+
+```sh
+sudo container-macos-kubeadm join 10.0.0.10:6443 \
+  --token abcdef.0123456789abcdef \
+  --discovery-token-ca-cert-hash sha256:<hash> \
+  --node-name macos-node-1 \
+  --network-mode compat \
+  --runtime-class macos-15-2=ghcr.io/jianliang00/macos-base:15.2 \
+  --runtime-class macos-15-4=ghcr.io/jianliang00/macos-base:15.4
+```
+
+Each additional RuntimeClass uses the node's selected network mode. Pods select
+the desired sandbox image through `spec.runtimeClassName`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: macos-15-2-smoke
+spec:
+  runtimeClassName: macos-15-2
+  containers:
+    - name: smoke
+      image: ghcr.io/example/macos-workload:15.2
+      command: ["/bin/sh", "-lc"]
+      args: ["sw_vers && sleep 3600"]
+```
+
+The CRI shim also accepts a Pod annotation override for the sandbox image:
+
+```yaml
+metadata:
+  annotations:
+    container-macos.io/sandbox-image: ghcr.io/jianliang00/macos-base:15.2
+```
+
+Clusters that expose this annotation to ordinary workload authors should
+enforce their own admission policy for accepted sandbox images and callers.
+
 ## API-Backed Pod
 
 ```yaml

--- a/docs/macos-guest-k8s-operator-guide.md
+++ b/docs/macos-guest-k8s-operator-guide.md
@@ -7,24 +7,40 @@ Kubernetes worker nodes. The control plane remains Linux.
 
 macOS workloads must opt in. Ordinary Pods must not land on macOS nodes.
 
-Required node labels:
+`container-macos-kubeadm join` registers the node labels and taints that match
+the selected network mode. Operators should not label or taint the node as a
+separate deployment step.
 
-```sh
-kubectl label node <mac-node> \
-  kubernetes.io/os=darwin \
-  apple.com/macos-container=true \
-  --overwrite
+Full-mode nodes are registered with these labels:
+
+```text
+kubernetes.io/os=darwin
+node.kubernetes.io/macos=true
+node.kubernetes.io/macos-network=full
 ```
 
-Required node taint:
+Full-mode nodes are registered with this taint:
 
-```sh
-kubectl taint node <mac-node> \
-  apple.com/macos-container=true:NoSchedule \
-  --overwrite
+```text
+node.kubernetes.io/macos=true:NoSchedule
 ```
 
-Required RuntimeClass:
+Compat-mode nodes are registered with these labels:
+
+```text
+kubernetes.io/os=darwin
+node.kubernetes.io/macos=true
+node.kubernetes.io/macos-network=compat
+```
+
+Compat-mode nodes are registered with these taints:
+
+```text
+node.kubernetes.io/macos=true:NoSchedule
+node.kubernetes.io/macos-network=compat:NoSchedule
+```
+
+Full-mode nodes use the `macos` RuntimeClass:
 
 ```yaml
 apiVersion: node.k8s.io/v1
@@ -35,19 +51,46 @@ handler: macos
 scheduling:
   nodeSelector:
     kubernetes.io/os: darwin
-    apple.com/macos-container: "true"
+    node.kubernetes.io/macos: "true"
+    node.kubernetes.io/macos-network: "full"
   tolerations:
-    - key: apple.com/macos-container
+    - key: node.kubernetes.io/macos
       operator: Equal
       value: "true"
       effect: NoSchedule
 ```
 
+Older macOS hosts joined with `--network-mode compat` use the `macos-compat`
+RuntimeClass:
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: macos-compat
+handler: macos-compat
+scheduling:
+  nodeSelector:
+    kubernetes.io/os: darwin
+    node.kubernetes.io/macos: "true"
+    node.kubernetes.io/macos-network: "compat"
+  tolerations:
+    - key: node.kubernetes.io/macos
+      operator: Equal
+      value: "true"
+      effect: NoSchedule
+    - key: node.kubernetes.io/macos-network
+      operator: Equal
+      value: "compat"
+      effect: NoSchedule
+```
+
 Admission policy should enforce these rules:
 
-- Pods selecting `kubernetes.io/os=darwin` must set `runtimeClassName: macos`.
-- Pods using `runtimeClassName: macos` must not set `.spec.os.name`.
-- Pods using `runtimeClassName: macos` must use a macOS workload image.
+- Pods selecting `kubernetes.io/os=darwin` must set `runtimeClassName: macos`
+  or `runtimeClassName: macos-compat`.
+- Pods using a macOS RuntimeClass must not set `.spec.os.name`.
+- Pods using a macOS RuntimeClass must use a macOS workload image.
 - Pods without the macOS RuntimeClass must not tolerate the macOS node taint.
 
 The admission implementation can be the cluster's existing policy engine. The
@@ -70,8 +113,11 @@ Do not set `linux` or `windows` for macOS workloads. The supported selection
 signals are:
 
 - `runtimeClassName: macos`
+- `runtimeClassName: macos-compat`
 - `kubernetes.io/os=darwin`
-- `apple.com/macos-container=true`
+- `node.kubernetes.io/macos=true`
+- `node.kubernetes.io/macos-network=full`
+- `node.kubernetes.io/macos-network=compat`
 - the macOS node taint and matching toleration supplied by RuntimeClass
   scheduling
 
@@ -96,6 +142,28 @@ spec:
 The Pod intentionally omits `.spec.os.name`; RuntimeClass scheduling carries the
 node selector and taint toleration.
 
+Compat-mode Pods use `runtimeClassName: macos-compat` and the same Pod OS
+contract:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: macos-compat-smoke
+  labels:
+    app: macos-compat-smoke
+spec:
+  runtimeClassName: macos-compat
+  containers:
+    - name: smoke
+      image: ghcr.io/example/macos-workload:15.2
+      command: ["/bin/sh", "-lc"]
+      args: ["sw_vers && sleep 3600"]
+```
+
+Compat-mode Pods have NAT egress only. They do not have a real Pod IP, ClusterIP
+Service semantics, NetworkPolicy, or inbound Service reachability.
+
 ## Static Pod
 
 Static Pods are placed directly on a macOS node by the local kubelet. They are
@@ -119,7 +187,8 @@ spec:
 ```
 
 When the kubelet is connected to the API server and the RuntimeClass object is
-available, static Pod manifests may set `runtimeClassName: macos`. Standalone
+available, static Pod manifests may set `runtimeClassName: macos` on full-mode
+nodes or `runtimeClassName: macos-compat` on compat-mode nodes. Standalone
 static Pod smoke tests should omit it and rely on the macOS-only CRI shim
 configuration.
 
@@ -139,8 +208,8 @@ The first production rollout supports a conservative macOS worker-node surface:
 | Port-forward | `kubectl port-forward` through the loopback streaming server |
 | Probes | exec, HTTP, and TCP kubelet probes |
 | Mounts | Supported CRI mount subset backed by boot-time `virtiofs` shares |
-| Service | Single-node IPv4 ClusterIP TCP/UDP through `container-kube-proxy-macos`; production release is blocked until this passes real API server validation |
-| NetworkPolicy | Not part of the first production rollout; keep disabled unless a separate validation effort promotes it |
+| Service | Full mode supports the kube-proxy-backed Service surface validated for the release. Compat mode does not provide ClusterIP or inbound Service semantics |
+| NetworkPolicy | Full mode may enable a separately validated implementation. Compat mode does not provide NetworkPolicy |
 
 Unsupported in the first production rollout:
 

--- a/docs/macos-guest-k8s-operator-guide.md
+++ b/docs/macos-guest-k8s-operator-guide.md
@@ -87,8 +87,9 @@ scheduling:
 
 Admission policy should enforce these rules:
 
-- Pods selecting `kubernetes.io/os=darwin` must set `runtimeClassName: macos`
-  or `runtimeClassName: macos-compat`.
+- Pods selecting `kubernetes.io/os=darwin` must set an approved macOS
+  RuntimeClass, such as `macos`, `macos-compat`, or an administrator-defined
+  RuntimeClass generated with `container-macos-kubeadm join --runtime-class`.
 - Pods using a macOS RuntimeClass must not set `.spec.os.name`.
 - Pods using a macOS RuntimeClass must use a macOS workload image.
 - Pods without the macOS RuntimeClass must not tolerate the macOS node taint.
@@ -114,6 +115,7 @@ signals are:
 
 - `runtimeClassName: macos`
 - `runtimeClassName: macos-compat`
+- administrator-defined macOS RuntimeClasses created with `--runtime-class`
 - `kubernetes.io/os=darwin`
 - `node.kubernetes.io/macos=true`
 - `node.kubernetes.io/macos-network=full`
@@ -124,7 +126,9 @@ signals are:
 ## Sandbox Image Selection
 
 The default RuntimeClass for a joined node uses the sandbox image configured
-with `container-macos-kubeadm join --sandbox-image`.
+with `container-macos-kubeadm join --sandbox-image`. Full-mode nodes expose this
+default as `runtimeClassName: macos`; compat-mode nodes expose it as
+`runtimeClassName: macos-compat`.
 
 Operators can expose additional administrator-defined sandbox images by
 repeating `--runtime-class <name>=<sandbox-image>` during join:
@@ -139,33 +143,96 @@ sudo container-macos-kubeadm join 10.0.0.10:6443 \
   --runtime-class macos-15-4=ghcr.io/jianliang00/macos-base:15.4
 ```
 
-Each additional RuntimeClass uses the node's selected network mode. Pods select
-the desired sandbox image through `spec.runtimeClassName`:
+Each additional RuntimeClass uses the node's selected network mode. The join
+command renders one CRI runtime handler and one
+`/usr/local/share/container-macos-node/manifests/runtimeclass-<name>.yaml`
+manifest for each entry. Apply the generated manifest from an admin workstation
+before scheduling Pods that reference it:
+
+```sh
+kubectl apply -f runtimeclass-macos-15-2.yaml
+kubectl apply -f runtimeclass-macos-15-4.yaml
+```
+
+The preferred selection mechanism is RuntimeClass. Pods select the desired
+administrator-defined sandbox image through `spec.runtimeClassName`:
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macos-15-2-smoke
+  name: macos-15-2-check
 spec:
   runtimeClassName: macos-15-2
+  automountServiceAccountToken: false
+  restartPolicy: Never
   containers:
-    - name: smoke
-      image: ghcr.io/example/macos-workload:15.2
+    - name: main
+      image: ghcr.io/jianliang00/macos-base-workload:15.2
       command: ["/bin/sh", "-lc"]
-      args: ["sw_vers && sleep 3600"]
+      args: ["sw_vers && echo macos-15-2-ok && sleep 3600"]
 ```
 
-The CRI shim also accepts a Pod annotation override for the sandbox image:
+### Pod-Level Sandbox Image Override
+
+If the cluster admission policy allows Pod-level sandbox image selection, a Pod
+can specify the sandbox image directly with the
+`container-macos.io/sandbox-image` annotation. The Pod must still set a macOS
+`runtimeClassName`; RuntimeClass selects the CRI handler, node scheduling rules,
+and node network mode, while the annotation overrides only the sandbox image.
 
 ```yaml
+apiVersion: v1
+kind: Pod
 metadata:
+  name: macos-sandbox-image-check
   annotations:
     container-macos.io/sandbox-image: ghcr.io/jianliang00/macos-base:15.2
+spec:
+  runtimeClassName: macos-compat
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  containers:
+    - name: main
+      image: ghcr.io/jianliang00/macos-base-workload:15.2
+      command: ["/bin/sh", "-lc"]
+      args: ["sw_vers && echo macos-sandbox-image-ok && sleep 3600"]
 ```
 
-Clusters that expose this annotation to ordinary workload authors should
-enforce their own admission policy for accepted sandbox images and callers.
+The annotation can also be used with an administrator-defined RuntimeClass:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: macos-runtimeclass-sandbox-image-check
+  annotations:
+    container-macos.io/sandbox-image: ghcr.io/jianliang00/macos-base:15.4
+spec:
+  runtimeClassName: macos-15-2
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  containers:
+    - name: main
+      image: ghcr.io/jianliang00/macos-base-workload:15.2
+      command: ["/bin/sh", "-lc"]
+      args: ["sw_vers && echo macos-runtimeclass-sandbox-image-ok && sleep 3600"]
+```
+
+Clusters that expose this annotation to ordinary workload authors should enforce
+their own admission policy for accepted sandbox images and callers.
+
+## Compat Validation Notes
+
+Compat-mode Pods use Virtualization.framework NAT and do not provide Pod CNI,
+kube-proxy, ClusterIP Service semantics, NetworkPolicy, or inbound Service
+reachability. Treat a compat node as a single-VM validation target unless the
+host capacity has been validated for parallel macOS VMs.
+
+For validation Pods that only check image pull, VM start, logs, and exec, set
+`automountServiceAccountToken: false`. Omit this field only when the workload
+needs Kubernetes API credentials or when the validation explicitly covers the
+projected ServiceAccount token volume.
 
 ## API-Backed Pod
 
@@ -173,20 +240,23 @@ enforce their own admission policy for accepted sandbox images and callers.
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macos-smoke
+  name: macos-check
   labels:
-    app: macos-smoke
+    app: macos-check
 spec:
   runtimeClassName: macos
+  automountServiceAccountToken: false
+  restartPolicy: Never
   containers:
-    - name: smoke
-      image: ghcr.io/example/macos-smoke:26.3
+    - name: main
+      image: ghcr.io/example/macos-workload:26.3
       command: ["/bin/sh", "-lc"]
       args: ["sw_vers && sleep 3600"]
 ```
 
 The Pod intentionally omits `.spec.os.name`; RuntimeClass scheduling carries the
-node selector and taint toleration.
+node selector and taint toleration. Remove `automountServiceAccountToken: false`
+when the workload needs to call the Kubernetes API with its ServiceAccount.
 
 Compat-mode Pods use `runtimeClassName: macos-compat` and the same Pod OS
 contract:
@@ -195,14 +265,16 @@ contract:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macos-compat-smoke
+  name: macos-compat-check
   labels:
-    app: macos-compat-smoke
+    app: macos-compat-check
 spec:
   runtimeClassName: macos-compat
+  automountServiceAccountToken: false
+  restartPolicy: Never
   containers:
-    - name: smoke
-      image: ghcr.io/example/macos-workload:15.2
+    - name: main
+      image: ghcr.io/jianliang00/macos-base-workload:15.2
       command: ["/bin/sh", "-lc"]
       args: ["sw_vers && sleep 3600"]
 ```
@@ -222,12 +294,12 @@ Use a manifest like this in the kubelet static Pod path:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macos-static-smoke
+  name: macos-static-check
   namespace: default
 spec:
   containers:
-    - name: smoke
-      image: ghcr.io/example/macos-smoke:26.3
+    - name: main
+      image: ghcr.io/example/macos-workload:26.3
       command: ["/bin/sh", "-lc"]
       args: ["sw_vers && sleep 3600"]
 ```
@@ -235,7 +307,7 @@ spec:
 When the kubelet is connected to the API server and the RuntimeClass object is
 available, static Pod manifests may set `runtimeClassName: macos` on full-mode
 nodes or `runtimeClassName: macos-compat` on compat-mode nodes. Standalone
-static Pod smoke tests should omit it and rely on the macOS-only CRI shim
+static Pod validation tests should omit it and rely on the macOS-only CRI shim
 configuration.
 
 ## First Rollout Workload Surface

--- a/docs/macos-guest-production-release-strategy.md
+++ b/docs/macos-guest-production-release-strategy.md
@@ -206,7 +206,46 @@ cluster deliberately supports both scheduling targets.
 Expose additional macOS sandbox images with repeated
 `container-macos-kubeadm join --runtime-class <name>=<sandbox-image>` options.
 Each additional RuntimeClass uses the joined node's selected network mode, and
-Pods select it with `spec.runtimeClassName`.
+Pods select it with `spec.runtimeClassName`. The join command writes generated
+RuntimeClass manifests under
+`/usr/local/share/container-macos-node/manifests/`; copy the matching
+`runtimeclass-<name>.yaml` files to an admin workstation and apply them before
+scheduling Pods that reference the new RuntimeClasses.
+
+Example compat-mode node exposing two macOS base images:
+
+```sh
+sudo container-macos-kubeadm join 10.0.0.10:6443 \
+  --token abcdef.0123456789abcdef \
+  --discovery-token-ca-cert-hash sha256:<hash> \
+  --node-name macos-node-1 \
+  --network-mode compat \
+  --runtime-class macos-15-2=ghcr.io/jianliang00/macos-base:15.2 \
+  --runtime-class macos-15-4=ghcr.io/jianliang00/macos-base:15.4
+```
+
+Example Pod selecting one of those RuntimeClasses:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: macos-15-2-check
+spec:
+  runtimeClassName: macos-15-2
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  containers:
+    - name: main
+      image: ghcr.io/jianliang00/macos-base-workload:15.2
+      command: ["/bin/sh", "-lc"]
+      args: ["sw_vers && echo macos-15-2-ok && sleep 3600"]
+```
+
+For compat-mode release validation, run macOS Pods sequentially on each host
+unless that host has been validated for multiple active macOS VMs. Set
+`automountServiceAccountToken: false` for validation Pods that do not need
+Kubernetes API credentials.
 
 Full-mode nodes advertise:
 

--- a/docs/macos-guest-production-release-strategy.md
+++ b/docs/macos-guest-production-release-strategy.md
@@ -183,23 +183,30 @@ pass `--dry-run` to inspect the full plan without writing files, contacting the
 API server, or starting services, and `--skip-start` to render files without
 loading launchd jobs.
 
-Apply the RuntimeClass manifest that matches the joined node mode from an admin
-workstation. From the source tree:
+Apply the RuntimeClass manifests that should be exposed to workloads from an
+admin workstation. The built-in default manifests are available from the source
+tree:
 
 ```sh
 kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos.yaml
 kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos-compat.yaml
 ```
 
-Installed packages also stage the same manifests under
+Installed packages also stage generated manifests under
 `/usr/local/share/container-macos-node/manifests/` on each macOS node. Copy the
-matching manifest to an admin workstation before applying it if the source tree
-is not available there.
+matching `runtimeclass-*.yaml` files to an admin workstation before applying
+them when the source tree is not available there or when `--runtime-class`
+generated additional RuntimeClasses.
 
 Use only `runtimeclass-macos.yaml` for a cluster that exposes full-mode macOS
 nodes only. Use only `runtimeclass-macos-compat.yaml` for a cluster that
 exposes older compat-mode macOS nodes only. Apply both manifests only when the
 cluster deliberately supports both scheduling targets.
+
+Expose additional macOS sandbox images with repeated
+`container-macos-kubeadm join --runtime-class <name>=<sandbox-image>` options.
+Each additional RuntimeClass uses the joined node's selected network mode, and
+Pods select it with `spec.runtimeClassName`.
 
 Full-mode nodes advertise:
 

--- a/docs/macos-guest-production-release-strategy.md
+++ b/docs/macos-guest-production-release-strategy.md
@@ -136,26 +136,99 @@ it to `system:node-proxier`, and allows kubeadm bootstrap tokens in
 ConfigMap and request a bounded kube-proxy ServiceAccount token during join.
 
 The supported deployment path is to install the package and then run the
-packaged bootstrap helper with kubeadm-compatible join arguments:
+packaged bootstrap helper with kubeadm-compatible join arguments. Select one
+network mode for each node before joining it:
+
+- `full` is the default mode. It requires macOS 26 or newer, configures the
+  vmnet-backed CNI path, starts kube-proxy, and registers the node for the
+  `macos` RuntimeClass.
+- `compat` is for older macOS hosts. It configures the CRI shim to use
+  Virtualization.framework NAT, skips Pod CNI configuration, skips kube-proxy,
+  and registers the node for the `macos-compat` RuntimeClass. Compat-mode Pods
+  have NAT egress, but they do not have a real Pod IP, ClusterIP Service
+  semantics, NetworkPolicy, or inbound Service reachability.
+
+Full-mode join:
 
 ```sh
 sudo container-macos-kubeadm join 10.0.0.10:6443 \
   --token abcdef.0123456789abcdef \
   --discovery-token-ca-cert-hash sha256:<hash> \
-  --node-name macos-node-1
+  --node-name macos-node-1 \
+  --network-mode full
+```
+
+Compat-mode join:
+
+```sh
+sudo container-macos-kubeadm join 10.0.0.10:6443 \
+  --token abcdef.0123456789abcdef \
+  --discovery-token-ca-cert-hash sha256:<hash> \
+  --node-name macos-node-1 \
+  --network-mode compat
 ```
 
 `container-macos-kubeadm join` reads the public `kube-public/cluster-info`
 ConfigMap, validates the discovered CA with `--discovery-token-ca-cert-hash`,
 then uses the bootstrap token to read the kubelet config ConfigMap when
-available and request a kube-proxy ServiceAccount token. It writes the CA
-certificate, kubelet bootstrap kubeconfig, kube-proxy kubeconfig, kubelet
-configuration, CRI/CNI/kube-proxy configuration, and launchd plists, then starts
+available. In full mode it also requests a kube-proxy ServiceAccount token. It
+writes the CA certificate, kubelet bootstrap kubeconfig, kubelet configuration,
+CRI configuration, launchd plists, and the matching RuntimeClass manifest. Full
+mode additionally writes CNI and kube-proxy configuration, then starts
 `container system`, `container-cri-shim-macos`, `container-kube-proxy-macos`,
-and kubelet in dependency order. Token-bearing kubeconfig contents are never
-expanded in logs. Operators can pass `--dry-run` to inspect the full plan
-without writing files, contacting the API server, or starting services, and
-`--skip-start` to render files without loading launchd jobs.
+and kubelet in dependency order. Compat mode starts `container system`, the CRI
+shim, and kubelet, and intentionally does not configure CNI or kube-proxy.
+Token-bearing kubeconfig contents are never expanded in logs. Operators can
+pass `--dry-run` to inspect the full plan without writing files, contacting the
+API server, or starting services, and `--skip-start` to render files without
+loading launchd jobs.
+
+Apply the RuntimeClass manifest that matches the joined node mode from an admin
+workstation. From the source tree:
+
+```sh
+kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos.yaml
+kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos-compat.yaml
+```
+
+Installed packages also stage the same manifests under
+`/usr/local/share/container-macos-node/manifests/` on each macOS node. Copy the
+matching manifest to an admin workstation before applying it if the source tree
+is not available there.
+
+Use only `runtimeclass-macos.yaml` for a cluster that exposes full-mode macOS
+nodes only. Use only `runtimeclass-macos-compat.yaml` for a cluster that
+exposes older compat-mode macOS nodes only. Apply both manifests only when the
+cluster deliberately supports both scheduling targets.
+
+Full-mode nodes advertise:
+
+```text
+kubernetes.io/os=darwin
+node.kubernetes.io/macos=true
+node.kubernetes.io/macos-network=full
+```
+
+Full-mode nodes also carry:
+
+```text
+node.kubernetes.io/macos=true:NoSchedule
+```
+
+Compat-mode nodes advertise:
+
+```text
+kubernetes.io/os=darwin
+node.kubernetes.io/macos=true
+node.kubernetes.io/macos-network=compat
+```
+
+Compat-mode nodes also carry:
+
+```text
+node.kubernetes.io/macos=true:NoSchedule
+node.kubernetes.io/macos-network=compat:NoSchedule
+```
 
 Operators can inspect a node with:
 
@@ -173,12 +246,14 @@ Operators can reset node-local Kubernetes configuration with:
 sudo container-macos-kubeadm reset --force
 ```
 
-`reset` stops kubelet, kube-proxy, and the CRI shim, flushes the kube-proxy PF
-anchor, and removes kubeadm-generated kubelet, CRI, CNI, kube-proxy, CA, and
-launchd configuration. It preserves the installed binaries and package payload.
-Use `--dry-run` to inspect the exact plan without changing the host. Use
-`--purge-state` only when intentionally removing kubelet, CRI/CNI state, and
-node logs:
+`reset` stops kubelet, kube-proxy when present, and the CRI shim, flushes the
+kube-proxy PF anchor when present, and removes kubeadm-generated kubelet, CRI,
+CNI, kube-proxy, CA, and launchd configuration. Compat-mode nodes do not create
+CNI or kube-proxy runtime configuration, so reset only removes the files and
+services that exist on the host. It preserves the installed binaries and
+package payload. Use `--dry-run` to inspect the exact plan without changing the
+host. Use `--purge-state` only when intentionally removing kubelet, CRI/CNI
+state, and node logs:
 
 ```sh
 sudo container-macos-kubeadm reset --force --purge-state
@@ -243,7 +318,9 @@ path:
 Use the kubelet log for node registration, pod lifecycle, probe, CRI, and log
 streaming failures. Use the CRI shim log for runtime, image, sandbox, container,
 exec, attach, and port-forward requests. Use the kube-proxy log for Service and
-EndpointSlice watch state, generated PF rules, and PF apply failures.
+EndpointSlice watch state, generated PF rules, and PF apply failures. Compat
+mode does not start kube-proxy, so the kube-proxy launchd job and log are
+expected to be absent on compat-mode nodes.
 
 The Darwin kubelet fork also uses the standard kubelet CRI log layout:
 
@@ -279,9 +356,9 @@ Rollback is node-local and must not require control-plane changes:
    kube-proxy, and NetworkPolicy controller.
 3. Restore the previous signed package or previous binary set.
 4. Restore previous kubelet, CRI, CNI, kube-proxy, and NetworkPolicy config.
-5. Validate PF config before reloading it.
+5. Validate PF config before reloading it on full-mode nodes.
 6. Start launchd services.
-7. Confirm CRI readiness, CNI readiness, kube-proxy PF anchor state, and Node
-   readiness before uncordoning.
+7. Confirm CRI readiness and Node readiness before uncordoning. On full-mode
+   nodes, also confirm CNI readiness and kube-proxy PF anchor state.
 
 Rollback artifacts must remain available for every production rollout.

--- a/packaging/macos-node/README.md
+++ b/packaging/macos-node/README.md
@@ -42,10 +42,58 @@ sudo container-macos-kubeadm join 10.0.0.10:6443 \
   --network-mode full
 ```
 
-`--network-mode full` is the default and uses the vmnet-backed CNI path. It
-requires macOS 26 or newer. On older macOS hosts, use `--network-mode compat`;
-that mode uses Virtualization.framework NAT, skips kube-proxy and Pod CNI
-setup, and writes a `macos-compat` RuntimeClass manifest.
+Choose the network mode for the node before joining it:
+
+- `--network-mode full` is the default. It requires macOS 26 or newer and uses
+  the vmnet-backed CNI path with kube-proxy. Full-mode Pods use the `macos`
+  RuntimeClass and get the normal macOS node labels:
+  `node.kubernetes.io/macos=true` and
+  `node.kubernetes.io/macos-network=full`. Full-mode nodes also carry the taint
+  `node.kubernetes.io/macos=true:NoSchedule`.
+- `--network-mode compat` is for older macOS hosts. It uses
+  Virtualization.framework NAT, skips Pod CNI setup, does not start
+  kube-proxy, and writes a `macos-compat` RuntimeClass manifest. Compat-mode
+  Pods use NAT egress only: they do not get a real Pod IP, ClusterIP Service
+  semantics, NetworkPolicy, or inbound Service reachability. Compat nodes get
+  `node.kubernetes.io/macos=true`,
+  `node.kubernetes.io/macos-network=compat`, and the taints
+  `node.kubernetes.io/macos=true:NoSchedule` and
+  `node.kubernetes.io/macos-network=compat:NoSchedule`.
+
+After joining a node, apply the matching RuntimeClass manifest from an admin
+workstation. From the source tree:
+
+```sh
+kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos.yaml
+kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos-compat.yaml
+```
+
+Installed packages also stage the same manifests under
+`/usr/local/share/container-macos-node/manifests/` on each macOS node. Copy the
+matching manifest to an admin workstation before applying it if the source tree
+is not available there.
+
+Apply only the manifest that matches the node mode when a cluster exposes a
+single macOS scheduling surface. Apply both manifests when the cluster
+intentionally supports both macOS 26+ full-mode nodes and older compat-mode
+nodes.
+
+Example compat workload:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: macos-compat-smoke
+spec:
+  runtimeClassName: macos-compat
+  restartPolicy: Never
+  containers:
+    - name: smoke
+      image: ghcr.io/example/macos-workload:15.2
+      command: ["/bin/sh", "-lc"]
+      args: ["sw_vers && sleep 3600"]
+```
 
 Use `container-macos-kubeadm status` to inspect installed files, generated
 configuration, the CRI socket, and launchd state. Use

--- a/packaging/macos-node/README.md
+++ b/packaging/macos-node/README.md
@@ -60,18 +60,38 @@ Choose the network mode for the node before joining it:
   `node.kubernetes.io/macos=true:NoSchedule` and
   `node.kubernetes.io/macos-network=compat:NoSchedule`.
 
-After joining a node, apply the matching RuntimeClass manifest from an admin
-workstation. From the source tree:
+To expose more than one macOS sandbox image on the same node, repeat
+`--runtime-class <name>=<sandbox-image>` during join. Each additional
+RuntimeClass uses the selected node network mode.
+
+```sh
+sudo container-macos-kubeadm join 10.0.0.10:6443 \
+  --token abcdef.0123456789abcdef \
+  --discovery-token-ca-cert-hash sha256:<hash> \
+  --node-name macos-node-1 \
+  --network-mode compat \
+  --runtime-class macos-15-2=ghcr.io/jianliang00/macos-base:15.2 \
+  --runtime-class macos-15-4=ghcr.io/jianliang00/macos-base:15.4
+```
+
+The generated CRI shim configuration registers one runtime handler per
+RuntimeClass. Pods select the desired sandbox image with
+`spec.runtimeClassName`, for example `macos-15-2`.
+
+After joining a node, apply the RuntimeClass manifests that should be exposed
+to the cluster from an admin workstation. The built-in default manifests are
+available from the source tree:
 
 ```sh
 kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos.yaml
 kubectl apply -f packaging/macos-node/manifests/runtimeclass-macos-compat.yaml
 ```
 
-Installed packages also stage the same manifests under
+Installed packages also stage generated manifests under
 `/usr/local/share/container-macos-node/manifests/` on each macOS node. Copy the
-matching manifest to an admin workstation before applying it if the source tree
-is not available there.
+matching `runtimeclass-*.yaml` files to an admin workstation before applying
+them when the source tree is not available there or when `--runtime-class`
+generated additional RuntimeClasses.
 
 Apply only the manifest that matches the node mode when a cluster exposes a
 single macOS scheduling surface. Apply both manifests when the cluster

--- a/packaging/macos-node/README.md
+++ b/packaging/macos-node/README.md
@@ -75,8 +75,10 @@ sudo container-macos-kubeadm join 10.0.0.10:6443 \
 ```
 
 The generated CRI shim configuration registers one runtime handler per
-RuntimeClass. Pods select the desired sandbox image with
-`spec.runtimeClassName`, for example `macos-15-2`.
+RuntimeClass. Each additional profile also renders a
+`runtimeclass-<name>.yaml` manifest under the package manifest directory. Pods
+select the desired sandbox image with `spec.runtimeClassName`, for example
+`macos-15-2`.
 
 After joining a node, apply the RuntimeClass manifests that should be exposed
 to the cluster from an admin workstation. The built-in default manifests are
@@ -93,27 +95,66 @@ matching `runtimeclass-*.yaml` files to an admin workstation before applying
 them when the source tree is not available there or when `--runtime-class`
 generated additional RuntimeClasses.
 
+For a node joined with `--runtime-class macos-15-2=...`, apply the generated
+manifest after copying it from the node:
+
+```sh
+kubectl apply -f runtimeclass-macos-15-2.yaml
+```
+
 Apply only the manifest that matches the node mode when a cluster exposes a
 single macOS scheduling surface. Apply both manifests when the cluster
 intentionally supports both macOS 26+ full-mode nodes and older compat-mode
 nodes.
 
-Example compat workload:
+Example compat validation workload:
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: macos-compat-smoke
+  name: macos-compat-check
 spec:
   runtimeClassName: macos-compat
+  automountServiceAccountToken: false
   restartPolicy: Never
   containers:
-    - name: smoke
-      image: ghcr.io/example/macos-workload:15.2
+    - name: main
+      image: ghcr.io/jianliang00/macos-base-workload:15.2
       command: ["/bin/sh", "-lc"]
-      args: ["sw_vers && sleep 3600"]
+      args: ["sw_vers && echo macos-compat-ok && sleep 3600"]
 ```
+
+Example workload selecting an administrator-defined RuntimeClass:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: macos-15-2-check
+spec:
+  runtimeClassName: macos-15-2
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  containers:
+    - name: main
+      image: ghcr.io/jianliang00/macos-base-workload:15.2
+      command: ["/bin/sh", "-lc"]
+      args: ["sw_vers && echo macos-15-2-ok && sleep 3600"]
+```
+
+The CRI shim also accepts a Pod annotation override for the sandbox image:
+
+```yaml
+metadata:
+  annotations:
+    container-macos.io/sandbox-image: ghcr.io/jianliang00/macos-base:15.2
+```
+
+Clusters that expose this annotation should enforce an admission policy for
+accepted sandbox images and callers. For basic compat-mode validation, run one
+macOS Pod at a time on a host. Set `automountServiceAccountToken: false` for
+validation Pods that do not need Kubernetes API credentials.
 
 Use `container-macos-kubeadm status` to inspect installed files, generated
 configuration, the CRI socket, and launchd state. Use


### PR DESCRIPTION
## Summary

- Document RuntimeClass-based macOS sandbox image selection and generated RuntimeClass manifests.
- Add Pod annotation examples for directly selecting a sandbox image in Pod configuration.
- Add compat-mode validation guidance for sequential Pods and ServiceAccount token automount behavior.

## Validation

- `git diff --check`