### PR TITLE
runtime: fix macOS workload ownership and user bootstrap

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -582,6 +582,7 @@ let package = Package(
                 "ContainerAPIClient",
                 "ContainerCommands",
                 .product(name: "Containerization", package: "containerization"),
+                .product(name: "ContainerizationArchive", package: "containerization"),
                 .product(name: "ContainerizationOCI", package: "containerization"),
                 "ContainerResource",
                 "ContainerSandboxServiceClient",

--- a/Sources/Helpers/MacOSGuestAgent/MacOSGuestAgent.swift
+++ b/Sources/Helpers/MacOSGuestAgent/MacOSGuestAgent.swift
@@ -23,7 +23,8 @@ import RuntimeMacOSSidecarShared
 struct MacOSGuestAgent: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "container-macos-guest-agent",
-        abstract: "Guest-side vsock agent for container-runtime-macos"
+        abstract: "Guest-side vsock agent for container-runtime-macos",
+        subcommands: [ExecHelper.self]
     )
 
     @Option(name: .long, help: "vsock listen port")
@@ -35,6 +36,24 @@ struct MacOSGuestAgent: ParsableCommand {
         logAgentStartupContext()
         let listener = try VsockListener(port: port)
         try listener.serveForever()
+    }
+
+    struct ExecHelper: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "exec-helper",
+            abstract: "Internal process launcher",
+            shouldDisplay: false
+        )
+
+        @Option(name: .long, help: "File descriptor containing the exec payload")
+        var payloadFD: Int32
+
+        @Option(name: .long, help: "File descriptor used to report exec startup errors")
+        var statusFD: Int32
+
+        mutating func run() throws {
+            runExecHelper(payloadFD: payloadFD, statusFD: statusFD)
+        }
     }
 }
 
@@ -735,6 +754,10 @@ struct GuestAgentExecIdentity {
         uid != currentIdentity.uid || gid != currentIdentity.gid || !supplementalGroups.isEmpty
     }
 
+    func requiresUserBootstrapSession(agentEUID: uid_t = geteuid()) -> Bool {
+        agentEUID == 0 && uid != 0
+    }
+
     static func resolve(from frame: GuestAgentFrame) throws -> Self? {
         let supplementalGroups = frame.supplementalGroups ?? []
         if let user = frame.user, !user.isEmpty {
@@ -829,6 +852,47 @@ struct GuestAgentExecIdentity {
     }
 }
 
+struct GuestAgentExecBootstrapPayload: Codable {
+    let executable: String
+    let arguments: [String]
+    let environment: [String]
+    let workingDirectory: String?
+    let uid: UInt32
+    let gid: UInt32
+    let supplementalGroups: [UInt32]
+
+    init(
+        executable: String,
+        arguments: [String],
+        environment: [String],
+        workingDirectory: String?,
+        identity: GuestAgentExecIdentity
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.environment = environment
+        self.workingDirectory = workingDirectory
+        self.uid = UInt32(identity.uid)
+        self.gid = UInt32(identity.gid)
+        self.supplementalGroups = identity.supplementalGroups.map { UInt32($0) }
+    }
+
+    var identity: GuestAgentExecIdentity {
+        .init(
+            uid: uid_t(uid),
+            gid: gid_t(gid),
+            supplementalGroups: supplementalGroups.map { gid_t($0) }
+        )
+    }
+}
+
+private struct UserBootstrapLaunch {
+    let executable: String
+    let arguments: [String]
+    let environment: [String]
+    let payloadFD: Int32
+}
+
 private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked Sendable {
     private let pid: pid_t
     private let terminal: Bool
@@ -867,15 +931,30 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
         identity: GuestAgentExecIdentity,
         connection: AgentConnection
     ) throws -> SpawnedProcessSession {
-        let preparedExec = PreparedCStringArray([executable] + arguments)
-        let preparedExecutableSearch = PreparedCStringArray(
-            executableSearchCandidates(executable: executable, environment: environment)
-        )
-        let preparedEnv = PreparedCStringArray(environment)
-        let preparedWorkingDirectory = workingDirectory.map(PreparedCString.init)
-
         let execStatus = try makePipe()
-        try setCloseOnExec(execStatus.writeEnd)
+        let bootstrapLaunch = try makeUserBootstrapLaunchIfNeeded(
+            executable: executable,
+            arguments: arguments,
+            environment: environment,
+            workingDirectory: workingDirectory,
+            identity: identity,
+            statusFD: execStatus.writeEnd
+        )
+        if bootstrapLaunch == nil {
+            try setCloseOnExec(execStatus.writeEnd)
+        }
+
+        let childExecutable = bootstrapLaunch?.executable ?? executable
+        let childArguments = bootstrapLaunch?.arguments ?? arguments
+        let childEnvironment = bootstrapLaunch?.environment ?? environment
+        let childIdentity = bootstrapLaunch == nil ? identity : GuestAgentExecIdentity.currentProcess()
+        let childWorkingDirectory = bootstrapLaunch == nil ? workingDirectory : nil
+        let preparedExec = PreparedCStringArray([childExecutable] + childArguments)
+        let preparedExecutableSearch = PreparedCStringArray(
+            executableSearchCandidates(executable: childExecutable, environment: childEnvironment)
+        )
+        let preparedEnv = PreparedCStringArray(childEnvironment)
+        let preparedWorkingDirectory = childWorkingDirectory.map(PreparedCString.init)
 
         var stdinPipe: RawPipe?
         var stdoutPipe: RawPipe?
@@ -897,6 +976,7 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
         guard pid >= 0 else {
             closeIfValid(execStatus.readEnd)
             closeIfValid(execStatus.writeEnd)
+            closeIfValid(bootstrapLaunch?.payloadFD)
             closeIfValid(masterFD)
             closeIfValid(slaveFD)
             closePipe(stdinPipe)
@@ -915,7 +995,7 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
                     arguments: preparedExec.pointer,
                     environment: preparedEnv.pointer,
                     workingDirectory: preparedWorkingDirectory?.pointer,
-                    identity: identity,
+                    identity: childIdentity,
                     stdinFD: slaveFD,
                     stdoutFD: slaveFD,
                     stderrFD: slaveFD,
@@ -931,7 +1011,7 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
                     arguments: preparedExec.pointer,
                     environment: preparedEnv.pointer,
                     workingDirectory: preparedWorkingDirectory?.pointer,
-                    identity: identity,
+                    identity: childIdentity,
                     stdinFD: stdinPipe?.readEnd ?? -1,
                     stdoutFD: stdoutPipe?.writeEnd ?? -1,
                     stderrFD: stderrPipe?.writeEnd ?? -1,
@@ -941,12 +1021,16 @@ private final class SpawnedProcessSession: GuestAgentProcessSession, @unchecked 
         }
 
         closeIfValid(execStatus.writeEnd)
+        closeIfValid(bootstrapLaunch?.payloadFD)
         closeIfValid(slaveFD)
         closeIfValid(stdinPipe?.readEnd)
         closeIfValid(stdoutPipe?.writeEnd)
         closeIfValid(stderrPipe?.writeEnd)
 
-        if let errorCode = try readExecStatus(execStatus.readEnd) {
+        if let errorCode = try readExecStatus(
+            execStatus.readEnd,
+            requireHelperReady: bootstrapLaunch != nil
+        ) {
             closeIfValid(masterFD)
             closeIfValid(stdinPipe?.writeEnd)
             closeIfValid(stdoutPipe?.readEnd)
@@ -1179,6 +1263,16 @@ private func closeIfValid(_ fd: Int32?) {
     _ = Darwin.close(fd)
 }
 
+private func clearCloseOnExec(_ fd: Int32) throws {
+    let flags = fcntl(fd, F_GETFD)
+    guard flags != -1 else {
+        throw POSIXError.fromErrno()
+    }
+    guard fcntl(fd, F_SETFD, flags & ~FD_CLOEXEC) == 0 else {
+        throw POSIXError.fromErrno()
+    }
+}
+
 private func setCloseOnExec(_ fd: Int32) throws {
     let flags = fcntl(fd, F_GETFD)
     guard flags != -1 else {
@@ -1189,8 +1283,22 @@ private func setCloseOnExec(_ fd: Int32) throws {
     }
 }
 
-private func readExecStatus(_ fd: Int32) throws -> Int32? {
+private let execHelperReadyStatus: Int32 = -1
+
+private func readExecStatus(_ fd: Int32, requireHelperReady: Bool = false) throws -> Int32? {
     defer { closeIfValid(fd) }
+    if requireHelperReady {
+        guard let firstStatus = try readExecStatusCode(fd) else {
+            throw POSIXError(.EIO)
+        }
+        if firstStatus != execHelperReadyStatus {
+            return firstStatus
+        }
+    }
+    return try readExecStatusCode(fd)
+}
+
+private func readExecStatusCode(_ fd: Int32) throws -> Int32? {
     var code: Int32 = 0
     let bytes = withUnsafeMutablePointer(to: &code) {
         Darwin.read(fd, $0, MemoryLayout<Int32>.size)
@@ -1202,6 +1310,14 @@ private func readExecStatus(_ fd: Int32) throws -> Int32? {
         throw POSIXError(.EIO)
     }
     return code
+}
+
+private func writeExecStatus(_ code: Int32, to fd: Int32) -> Bool {
+    var status = code
+    let bytes = withUnsafePointer(to: &status) {
+        Darwin.write(fd, $0, MemoryLayout<Int32>.size)
+    }
+    return bytes == MemoryLayout<Int32>.size
 }
 
 private let defaultExecutableSearchPath = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
@@ -1248,6 +1364,200 @@ private func execWithPathSearch(
         index += 1
     }
     return permissionErrno ?? Int32(ENOENT)
+}
+
+private func makeUserBootstrapLaunchIfNeeded(
+    executable: String,
+    arguments: [String],
+    environment: [String],
+    workingDirectory: String?,
+    identity: GuestAgentExecIdentity,
+    statusFD: Int32
+) throws -> UserBootstrapLaunch? {
+    guard identity.requiresUserBootstrapSession() else {
+        return nil
+    }
+
+    let agentPath = try currentGuestAgentExecutablePath()
+    let payload = GuestAgentExecBootstrapPayload(
+        executable: executable,
+        arguments: arguments,
+        environment: environment,
+        workingDirectory: workingDirectory,
+        identity: identity
+    )
+    let payloadFD = try makeTemporaryPayloadFile(payload)
+    do {
+        try clearCloseOnExec(payloadFD)
+        try clearCloseOnExec(statusFD)
+    } catch {
+        closeIfValid(payloadFD)
+        throw error
+    }
+
+    return UserBootstrapLaunch(
+        executable: "/bin/launchctl",
+        arguments: [
+            "asuser",
+            "\(identity.uid)",
+            agentPath,
+            "exec-helper",
+            "--payload-fd",
+            "\(payloadFD)",
+            "--status-fd",
+            "\(statusFD)",
+        ],
+        environment: ["PATH=\(defaultExecutableSearchPath)"],
+        payloadFD: payloadFD
+    )
+}
+
+private func currentGuestAgentExecutablePath() throws -> String {
+    let candidates: [String?] = [
+        Bundle.main.executableURL?.path,
+        CommandLine.arguments.first,
+        "/usr/local/bin/container-macos-guest-agent",
+    ]
+    for candidate in candidates.compactMap({ $0 }) {
+        guard candidate.contains("/") else {
+            continue
+        }
+        if FileManager.default.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+    }
+    throw POSIXError(.ENOENT)
+}
+
+private func makeTemporaryPayloadFile(_ payload: GuestAgentExecBootstrapPayload) throws -> Int32 {
+    let data = try JSONEncoder().encode(payload)
+    var template = Array("/tmp/container-macos-guest-agent-exec.XXXXXX".utf8CString)
+    let fd = template.withUnsafeMutableBufferPointer { buffer -> Int32 in
+        guard let baseAddress = buffer.baseAddress else {
+            return -1
+        }
+        return mkstemp(baseAddress)
+    }
+    guard fd >= 0 else {
+        throw POSIXError.fromErrno()
+    }
+    let path = template.withUnsafeBufferPointer { buffer -> String in
+        String(cString: buffer.baseAddress!)
+    }
+    _ = unlink(path)
+    do {
+        try writeAll(data, to: fd)
+        guard lseek(fd, 0, SEEK_SET) == 0 else {
+            throw POSIXError.fromErrno()
+        }
+        return fd
+    } catch {
+        closeIfValid(fd)
+        throw error
+    }
+}
+
+private func readAll(from fd: Int32) throws -> Data {
+    var result = Data()
+    var buffer = [UInt8](repeating: 0, count: 16 * 1024)
+    while true {
+        let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer -> Int in
+            guard let baseAddress = rawBuffer.baseAddress else { return 0 }
+            return Darwin.read(fd, baseAddress, rawBuffer.count)
+        }
+        if bytesRead > 0 {
+            result.append(contentsOf: buffer.prefix(bytesRead))
+            continue
+        }
+        if bytesRead == 0 {
+            return result
+        }
+        let code = errno
+        if code == EINTR {
+            continue
+        }
+        throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+    }
+}
+
+private func writeAll(_ data: Data, to fd: Int32) throws {
+    try data.withUnsafeBytes { rawBuffer in
+        guard let baseAddress = rawBuffer.baseAddress else { return }
+        var totalWritten = 0
+        while totalWritten < rawBuffer.count {
+            let written = Darwin.write(
+                fd,
+                baseAddress.advanced(by: totalWritten),
+                rawBuffer.count - totalWritten
+            )
+            if written > 0 {
+                totalWritten += written
+                continue
+            }
+            if written == 0 {
+                throw POSIXError(.EPIPE)
+            }
+            let code = errno
+            if code == EINTR {
+                continue
+            }
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+    }
+}
+
+private func runExecHelper(payloadFD: Int32, statusFD: Int32) -> Never {
+    func fail(_ code: Int32) -> Never {
+        _ = writeExecStatus(code, to: statusFD)
+        _exit(127)
+    }
+
+    var openPayloadFD: Int32? = payloadFD
+    do {
+        let payloadData = try readAll(from: payloadFD)
+        closeIfValid(openPayloadFD)
+        openPayloadFD = nil
+        let payload = try JSONDecoder().decode(GuestAgentExecBootstrapPayload.self, from: payloadData)
+        let preparedExec = PreparedCStringArray([payload.executable] + payload.arguments)
+        let preparedExecutableSearch = PreparedCStringArray(
+            executableSearchCandidates(executable: payload.executable, environment: payload.environment)
+        )
+        let preparedEnv = PreparedCStringArray(payload.environment)
+
+        guard writeExecStatus(execHelperReadyStatus, to: statusFD) else {
+            _exit(127)
+        }
+        applyProcessIdentity(payload.identity, fail: fail)
+        if let workingDirectory = payload.workingDirectory, chdir(workingDirectory) != 0 {
+            fail(Int32(errno))
+        }
+        do {
+            try setCloseOnExec(statusFD)
+        } catch {
+            fail(posixErrorCode(error))
+        }
+        fail(
+            execWithPathSearch(
+                preparedExecutableSearch.pointer,
+                arguments: preparedExec.pointer,
+                environment: preparedEnv.pointer
+            )
+        )
+    } catch {
+        closeIfValid(openPayloadFD)
+        fail(posixErrorCode(error))
+    }
+}
+
+private func posixErrorCode(_ error: Error) -> Int32 {
+    if let error = error as? POSIXError {
+        return error.code.rawValue
+    }
+    let nsError = error as NSError
+    if nsError.domain == NSPOSIXErrorDomain {
+        return Int32(nsError.code)
+    }
+    return Int32(EINVAL)
 }
 
 private func wifexited(_ status: Int32) -> Bool {
@@ -1315,6 +1625,15 @@ private func runChild(
         _ = Darwin.close(stderrFD)
     }
 
+    applyProcessIdentity(identity, fail: fail)
+
+    if let workingDirectory, chdir(workingDirectory) != 0 {
+        fail(Int32(errno))
+    }
+    fail(execWithPathSearch(executableSearch, arguments: arguments, environment: environment))
+}
+
+private func applyProcessIdentity(_ identity: GuestAgentExecIdentity, fail: (Int32) -> Never) {
     let currentUID = geteuid()
     let currentGID = getegid()
 
@@ -1333,11 +1652,6 @@ private func runChild(
     if identity.uid != currentUID, setuid(identity.uid) != 0 {
         fail(Int32(errno))
     }
-
-    if let workingDirectory, chdir(workingDirectory) != 0 {
-        fail(Int32(errno))
-    }
-    fail(execWithPathSearch(executableSearch, arguments: arguments, environment: environment))
 }
 
 private func sendSignalToProcessTree(pid: pid_t, signal: Int32) throws {

--- a/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
@@ -1453,6 +1453,11 @@ extension MacOSSandboxService {
         let imageConfig: ContainerizationOCI.Image
     }
 
+    private struct ResolvedWorkloadRootfs {
+        let root: URL
+        let metadata: WorkloadRootfsMetadata
+    }
+
     private enum WorkloadLayerEntryKind {
         case directory
         case file
@@ -1463,6 +1468,33 @@ extension MacOSSandboxService {
         let url: URL
         let relativePath: String
         let kind: WorkloadLayerEntryKind
+    }
+
+    private struct WorkloadRootfsMetadata: Codable {
+        var entries: [String: WorkloadRootfsEntryMetadata] = [:]
+
+        mutating func removeEntryAndDescendants(at relativePath: String) {
+            entries = entries.filter { key, _ in
+                key != relativePath && !key.hasPrefix("\(relativePath)/")
+            }
+        }
+
+        mutating func removeChildren(under relativePath: String) {
+            if relativePath.isEmpty {
+                entries.removeAll()
+                return
+            }
+            entries = entries.filter { key, _ in
+                !key.hasPrefix("\(relativePath)/")
+            }
+        }
+    }
+
+    private struct WorkloadRootfsEntryMetadata: Codable {
+        let mode: UInt32?
+        let uid: UInt32?
+        let gid: UInt32?
+        let mtime: Int64?
     }
 
     private func resetImageBackedWorkloadsForColdBootIfNeeded() throws {
@@ -1545,7 +1577,7 @@ extension MacOSSandboxService {
 
         do {
             try await prepareGuestWorkloadInstanceDirectory(workloadID: workloadID, containerConfig: containerConfig)
-            try await injectDirectoryTree(from: hostRootfs, to: guestPayloadPath)
+            try await injectDirectoryTree(from: hostRootfs.root, metadata: hostRootfs.metadata, to: guestPayloadPath)
             try await writeGuestFile(from: metadataFile, to: guestMetadataPath)
 
             var updated = record.configuration
@@ -1770,7 +1802,7 @@ extension MacOSSandboxService {
         return mapImageBackedWorkloadProcessConfiguration(
             sessionConfiguration,
             guestPayloadPath: guestPayloadPath,
-            hostRootfs: hostRootfs
+            hostRootfs: hostRootfs.root
         )
     }
 
@@ -1882,19 +1914,25 @@ extension MacOSSandboxService {
         return joinGuestPath(guestPayloadPath, String(relativePath))
     }
 
-    private func unpackWorkloadRootfs(_ resolvedImage: ResolvedWorkloadImage) async throws -> URL {
+    private func unpackWorkloadRootfs(_ resolvedImage: ResolvedWorkloadImage) async throws -> ResolvedWorkloadRootfs {
         let fileManager = FileManager.default
         let cacheRoot = MacOSGuestCache.workloadRootfsCacheDirectory(fileManager: fileManager)
         let cachedDirectory = cacheRoot.appendingPathComponent(MacOSGuestCache.safeDigest(resolvedImage.imageDigest), isDirectory: true)
         let cachedRootfs = cachedDirectory.appendingPathComponent("rootfs", isDirectory: true)
+        let cachedMetadata = workloadRootfsMetadataURL(forRootfs: cachedRootfs)
         if fileManager.fileExists(atPath: cachedRootfs.path) {
-            return cachedRootfs
+            if fileManager.fileExists(atPath: cachedMetadata.path) {
+                return ResolvedWorkloadRootfs(root: cachedRootfs, metadata: try readWorkloadRootfsMetadata(from: cachedMetadata))
+            }
+            try fileManager.removeItem(at: cachedDirectory)
         }
 
         try fileManager.createDirectory(at: cacheRoot, withIntermediateDirectories: true)
         let stagingDirectory = cacheRoot.appendingPathComponent(".workload-\(UUID().uuidString)", isDirectory: true)
         let stagingRootfs = stagingDirectory.appendingPathComponent("rootfs", isDirectory: true)
+        let stagingMetadata = workloadRootfsMetadataURL(forRootfs: stagingRootfs)
         try fileManager.createDirectory(at: stagingRootfs, withIntermediateDirectories: true)
+        var rootfsMetadata = WorkloadRootfsMetadata()
 
         do {
             for (index, layer) in resolvedImage.manifest.layers.enumerated() {
@@ -1902,6 +1940,7 @@ extension MacOSSandboxService {
                     throw ContainerizationError(.notFound, message: "missing workload layer blob \(layer.digest)")
                 }
                 let extractedLayerDirectory = stagingDirectory.appendingPathComponent("layer-\(index)", isDirectory: true)
+                let layerMetadata = try readWorkloadLayerMetadata(from: layerContent.path)
                 let rejectedMembers = try ArchiveReader(file: layerContent.path).extractContents(to: extractedLayerDirectory)
                 guard rejectedMembers.isEmpty else {
                     throw ContainerizationError(
@@ -1909,16 +1948,25 @@ extension MacOSSandboxService {
                         message: "workload layer \(layer.digest) contains rejected archive members: \(rejectedMembers.joined(separator: ", "))"
                     )
                 }
-                try applyExtractedWorkloadLayer(at: extractedLayerDirectory, to: stagingRootfs)
+                try applyExtractedWorkloadLayer(
+                    at: extractedLayerDirectory,
+                    to: stagingRootfs,
+                    layerMetadata: layerMetadata,
+                    rootfsMetadata: &rootfsMetadata
+                )
                 try? fileManager.removeItem(at: extractedLayerDirectory)
             }
+            try writeWorkloadRootfsMetadata(rootfsMetadata, to: stagingMetadata)
 
             do {
                 try fileManager.moveItem(at: stagingDirectory, to: cachedDirectory)
             } catch {
                 if fileManager.fileExists(atPath: cachedRootfs.path) {
                     try? fileManager.removeItem(at: stagingDirectory)
-                    return cachedRootfs
+                    return ResolvedWorkloadRootfs(
+                        root: cachedRootfs,
+                        metadata: try readWorkloadRootfsMetadata(from: cachedMetadata)
+                    )
                 }
                 throw error
             }
@@ -1927,11 +1975,71 @@ extension MacOSSandboxService {
             throw error
         }
 
-        return cachedRootfs
+        return ResolvedWorkloadRootfs(root: cachedRootfs, metadata: rootfsMetadata)
     }
 
-    private func applyExtractedWorkloadLayer(at sourceRoot: URL, to destinationRoot: URL) throws {
-        try applyWhiteouts(from: sourceRoot, to: destinationRoot)
+    private func workloadRootfsMetadataURL(forRootfs rootfs: URL) -> URL {
+        rootfs.deletingLastPathComponent().appendingPathComponent("metadata.json")
+    }
+
+    private func readWorkloadRootfsMetadata(from url: URL) throws -> WorkloadRootfsMetadata {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(WorkloadRootfsMetadata.self, from: data)
+    }
+
+    private func writeWorkloadRootfsMetadata(_ metadata: WorkloadRootfsMetadata, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(metadata).write(to: url, options: .atomic)
+    }
+
+    private func readWorkloadLayerMetadata(from layer: URL) throws -> WorkloadRootfsMetadata {
+        let reader = try ArchiveReader(file: layer)
+        var metadata = WorkloadRootfsMetadata()
+        for (entry, _) in reader.makeStreamingIterator() {
+            guard let relativePath = normalizedWorkloadLayerRelativePath(entry.path) else {
+                continue
+            }
+            metadata.entries[relativePath] = WorkloadRootfsEntryMetadata(
+                mode: UInt32(entry.permissions),
+                uid: entry.owner.map { UInt32($0) },
+                gid: entry.group.map { UInt32($0) },
+                mtime: entry.modificationDate.map { Int64($0.timeIntervalSince1970) }
+            )
+        }
+        return metadata
+    }
+
+    private func normalizedWorkloadLayerRelativePath(_ rawPath: String?) -> String? {
+        guard var path = rawPath, !path.isEmpty else {
+            return nil
+        }
+        while path.hasPrefix("./") {
+            path.removeFirst(2)
+        }
+        while path.hasPrefix("/") {
+            path.removeFirst()
+        }
+        while path.hasSuffix("/") {
+            path.removeLast()
+        }
+        guard !path.isEmpty && path != "." else {
+            return nil
+        }
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.contains(where: { $0.isEmpty || $0 == "." || $0 == ".." }) else {
+            return nil
+        }
+        return path
+    }
+
+    private func applyExtractedWorkloadLayer(
+        at sourceRoot: URL,
+        to destinationRoot: URL,
+        layerMetadata: WorkloadRootfsMetadata,
+        rootfsMetadata: inout WorkloadRootfsMetadata
+    ) throws {
+        try applyWhiteouts(from: sourceRoot, to: destinationRoot, rootfsMetadata: &rootfsMetadata)
         for entry in try walkWorkloadLayerTree(root: sourceRoot) {
             guard !isWhiteoutEntry(entry.url) else {
                 continue
@@ -1945,10 +2053,17 @@ extension MacOSSandboxService {
             case .symlink:
                 try recreateSymbolicLink(from: entry.url, to: destinationURL)
             }
+            if let metadata = layerMetadata.entries[entry.relativePath] {
+                rootfsMetadata.entries[entry.relativePath] = metadata
+            }
         }
     }
 
-    private func applyWhiteouts(from sourceRoot: URL, to destinationRoot: URL) throws {
+    private func applyWhiteouts(
+        from sourceRoot: URL,
+        to destinationRoot: URL,
+        rootfsMetadata: inout WorkloadRootfsMetadata
+    ) throws {
         let fileManager = FileManager.default
         for entry in try walkWorkloadLayerTree(root: sourceRoot) {
             let basename = entry.url.lastPathComponent
@@ -1963,6 +2078,7 @@ extension MacOSSandboxService {
                         try fileManager.removeItem(at: child)
                     }
                 }
+                rootfsMetadata.removeChildren(under: relativeDirectory == "." ? "" : relativeDirectory)
                 try fileManager.removeItem(at: entry.url)
                 continue
             }
@@ -1977,6 +2093,7 @@ extension MacOSSandboxService {
             if fileManager.fileExists(atPath: targetURL.path) {
                 try fileManager.removeItem(at: targetURL)
             }
+            rootfsMetadata.removeEntryAndDescendants(at: targetRelativePath)
             try fileManager.removeItem(at: entry.url)
         }
     }
@@ -2162,35 +2279,48 @@ extension MacOSSandboxService {
         closeSessionResources(session)
     }
 
-    private func injectDirectoryTree(from sourceRoot: URL, to guestRoot: String) async throws {
+    private func injectDirectoryTree(
+        from sourceRoot: URL,
+        metadata: WorkloadRootfsMetadata,
+        to guestRoot: String
+    ) async throws {
         for entry in try walkWorkloadLayerTree(root: sourceRoot) {
             let destinationPath = joinGuestPath(guestRoot, entry.relativePath)
+            let entryMetadata = metadata.entries[entry.relativePath]
             switch entry.kind {
             case .directory:
-                try await createGuestDirectory(from: entry.url, to: destinationPath)
+                try await createGuestDirectory(from: entry.url, metadata: entryMetadata, to: destinationPath)
             case .file:
-                try await writeGuestFile(from: entry.url, to: destinationPath)
+                try await writeGuestFile(from: entry.url, metadata: entryMetadata, to: destinationPath)
             case .symlink:
-                try await createGuestSymbolicLink(from: entry.url, to: destinationPath)
+                try await createGuestSymbolicLink(from: entry.url, metadata: entryMetadata, to: destinationPath)
             }
         }
     }
 
-    private func createGuestDirectory(from source: URL, to destinationPath: String) async throws {
+    private func createGuestDirectory(
+        from source: URL,
+        metadata: WorkloadRootfsEntryMetadata?,
+        to destinationPath: String
+    ) async throws {
         try await MacOSSidecarFileTransfer.createDirectory(
             at: destinationPath,
-            options: .init(mode: hostFileMode(at: source), mtime: hostModificationTime(at: source)),
+            options: fileTransferOptions(for: source, metadata: metadata),
             begin: { payload in
                 try await self.sendFSBegin(payload)
             }
         )
     }
 
-    private func writeGuestFile(from source: URL, to destinationPath: String) async throws {
+    private func writeGuestFile(
+        from source: URL,
+        metadata: WorkloadRootfsEntryMetadata? = nil,
+        to destinationPath: String
+    ) async throws {
         try await MacOSSidecarFileTransfer.writeFile(
             from: source,
             to: destinationPath,
-            options: .init(mode: hostFileMode(at: source), mtime: hostModificationTime(at: source), overwrite: true),
+            options: fileTransferOptions(for: source, metadata: metadata, overwrite: true),
             begin: { payload in
                 try await self.sendFSBegin(payload)
             },
@@ -2203,15 +2333,34 @@ extension MacOSSandboxService {
         )
     }
 
-    private func createGuestSymbolicLink(from source: URL, to destinationPath: String) async throws {
+    private func createGuestSymbolicLink(
+        from source: URL,
+        metadata: WorkloadRootfsEntryMetadata?,
+        to destinationPath: String
+    ) async throws {
         let target = try FileManager.default.destinationOfSymbolicLink(atPath: source.path)
         try await MacOSSidecarFileTransfer.createSymbolicLink(
             at: destinationPath,
             target: target,
-            options: .init(mtime: hostModificationTime(at: source), overwrite: true),
+            options: fileTransferOptions(for: source, metadata: metadata, includeMode: false, overwrite: true),
             begin: { payload in
                 try await self.sendFSBegin(payload)
             }
+        )
+    }
+
+    private func fileTransferOptions(
+        for source: URL,
+        metadata: WorkloadRootfsEntryMetadata?,
+        includeMode: Bool = true,
+        overwrite: Bool = true
+    ) -> MacOSSidecarFileTransfer.WriteOptions {
+        MacOSSidecarFileTransfer.WriteOptions(
+            mode: includeMode ? metadata?.mode ?? hostFileMode(at: source) : nil,
+            uid: metadata?.uid,
+            gid: metadata?.gid,
+            mtime: metadata?.mtime ?? hostModificationTime(at: source),
+            overwrite: overwrite
         )
     }
 

--- a/Tests/MacOSGuestAgentTests/GuestAgentFileTransferTransactionTests.swift
+++ b/Tests/MacOSGuestAgentTests/GuestAgentFileTransferTransactionTests.swift
@@ -383,8 +383,18 @@ struct GuestAgentFileTransferTransactionTests {
     }
 
     @Test
+    func rootAgentUsesUserBootstrapForNonRootExecIdentity() throws {
+        let nonRootIdentity = GuestAgentExecIdentity(uid: 501, gid: 20, supplementalGroups: [])
+        let rootIdentity = GuestAgentExecIdentity(uid: 0, gid: 0, supplementalGroups: [])
+
+        #expect(nonRootIdentity.requiresUserBootstrapSession(agentEUID: 0))
+        #expect(!nonRootIdentity.requiresUserBootstrapSession(agentEUID: nonRootIdentity.uid))
+        #expect(!rootIdentity.requiresUserBootstrapSession(agentEUID: 0))
+    }
+
+    @Test
     func execIdentityRejectsUnknownNamedUser() throws {
-        let unknownUser = "codex-user-\(UUID().uuidString)"
+        let unknownUser = "missing-user-\(UUID().uuidString)"
 
         #expect(throws: (any Error).self) {
             _ = try GuestAgentExecIdentity.resolve(

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSImageBackedWorkloadTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSImageBackedWorkloadTests.swift
@@ -17,7 +17,9 @@
 #if os(macOS)
 import ContainerResource
 import Containerization
+import ContainerizationArchive
 import ContainerizationOCI
+import Darwin
 import Foundation
 import Logging
 import Testing
@@ -180,6 +182,14 @@ struct MacOSImageBackedWorkloadTests {
         #expect(injectedPaths.contains("\(guestRoot)/etc"))
         #expect(injectedPaths.contains("\(guestRoot)/etc/config.txt"))
         #expect(!injectedPaths.contains("\(guestRoot)/tmp/stale.txt"))
+
+        let workspaceBegin = try #require(requests.first(where: { $0.fsBegin?.path == "\(guestRoot)/workspace" })?.fsBegin)
+        #expect(workspaceBegin.uid == 501)
+        #expect(workspaceBegin.gid == 20)
+
+        let helloBegin = try #require(requests.first(where: { $0.fsBegin?.path == "\(guestRoot)/bin/hello" })?.fsBegin)
+        #expect(helloBegin.uid == 501)
+        #expect(helloBegin.gid == 20)
 
         let metadataPayload = try #require(
             requests.first(where: { $0.fsBegin?.path == "/var/lib/container/workloads/\(workloadID)/meta.json" })?.fsBegin?.inlineData
@@ -1019,7 +1029,14 @@ extension MacOSImageBackedWorkloadTests {
 
         let layer1Tar = directory.appendingPathComponent("layer1.tar")
         let layer2Tar = directory.appendingPathComponent("layer2.tar")
-        try createTarArchive(from: layer1Root, to: layer1Tar)
+        try createTarArchive(
+            from: layer1Root,
+            to: layer1Tar,
+            ownerOverrides: [
+                "bin/hello": (uid: 501, gid: 20),
+                "workspace": (uid: 501, gid: 20),
+            ]
+        )
         try createTarArchive(from: layer2Root, to: layer2Tar)
 
         let layer1Digest = "sha256:layer1-\(UUID().uuidString)"
@@ -1094,18 +1111,65 @@ extension MacOSImageBackedWorkloadTests {
         return url
     }
 
-    private static func createTarArchive(from sourceRoot: URL, to outputURL: URL) throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
-        process.arguments = ["-cf", outputURL.path, "-C", sourceRoot.path, "."]
-        let stderr = Pipe()
-        process.standardError = stderr
-        try process.run()
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            let message = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "failed to create tar archive"
-            throw NSError(domain: "MacOSImageBackedWorkloadTests", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: message])
+    private static func createTarArchive(
+        from sourceRoot: URL,
+        to outputURL: URL,
+        ownerOverrides: [String: (uid: UInt32, gid: UInt32)] = [:]
+    ) throws {
+        let writer = try ArchiveWriter(format: .pax, filter: .none, file: outputURL)
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: sourceRoot,
+                includingPropertiesForKeys: [.fileResourceTypeKey],
+                options: .producesRelativePathURLs
+            )
+        else {
+            throw POSIXError(.ENOTDIR)
         }
+
+        for case let relativeURL as URL in enumerator {
+            let relativePath = relativeURL.relativePath
+            let sourceURL = sourceRoot.appendingPathComponent(relativePath)
+            let values = try sourceURL.resourceValues(forKeys: [.fileResourceTypeKey])
+            guard let fileType = values.fileResourceType else {
+                continue
+            }
+            guard [.directory, .regular, .symbolicLink].contains(fileType) else {
+                continue
+            }
+
+            var statInfo = stat()
+            guard lstat(sourceURL.path, &statInfo) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+
+            let entry = WriteEntry()
+            entry.path = relativePath
+            entry.fileType = fileType
+            entry.permissions = statInfo.st_mode & 0o7777
+            entry.modificationDate = Date(timeIntervalSince1970: TimeInterval(statInfo.st_mtimespec.tv_sec))
+            if let owner = ownerOverrides[relativePath] {
+                entry.owner = uid_t(owner.uid)
+                entry.group = gid_t(owner.gid)
+            } else {
+                entry.owner = statInfo.st_uid
+                entry.group = statInfo.st_gid
+            }
+
+            switch fileType {
+            case .regular:
+                let data = try Data(contentsOf: sourceURL)
+                entry.size = Int64(data.count)
+                try writer.writeEntry(entry: entry, data: data)
+            case .symbolicLink:
+                entry.symlinkTarget = try FileManager.default.destinationOfSymbolicLink(atPath: sourceURL.path)
+                try writer.writeEntry(entry: entry, data: nil as UnsafeRawBufferPointer?)
+            default:
+                entry.size = 0
+                try writer.writeEntry(entry: entry, data: nil as UnsafeRawBufferPointer?)
+            }
+        }
+        try writer.finishEncoding()
     }
 
     private static func baseContainerConfiguration(indexDigest: String) throws -> ContainerConfiguration {

--- a/docs/macos-guest-workload-user-bootstrap.md
+++ b/docs/macos-guest-workload-user-bootstrap.md
@@ -1,0 +1,85 @@
+# macOS Workload User Bootstrap Context
+
+macOS workload processes can run as a non-root image user, such as `admin`.
+For those processes, the effective uid/gid is not enough to reproduce a normal
+user session. Some system frameworks resolve per-user state through the process
+bootstrap namespace managed by `launchd`. Keychain Services is one visible
+example: a process with `uid=501` can still use the System bootstrap namespace
+and then `security find-identity` without an explicit keychain path reads the
+System/root search list instead of the user's search list.
+
+The guest agent therefore starts non-root workload commands in the target user's
+bootstrap namespace before dropping privileges. This gives tools such as
+`security`, `codesign`, and `xcodebuild` the same user-domain keychain view that
+they get from a login-style user session.
+
+## Runtime Flow
+
+The guest agent is installed as a root LaunchDaemon inside the macOS guest. When
+the runtime asks it to start a workload command, it resolves the target identity
+from the exec request:
+
+- root targets keep the original direct fork/exec path.
+- non-root targets started by the root guest agent use `launchctl asuser <uid>`.
+
+For a non-root target, the guest agent creates an anonymous temporary payload
+file, writes the intended executable, arguments, environment, working directory,
+uid, gid, and supplemental groups to it, and passes the open file descriptor to
+an internal `exec-helper` subcommand. The helper runs under the target user's
+bootstrap namespace while it is still root, then applies the requested groups,
+gid, and uid, changes to the requested working directory, and executes the final
+workload command.
+
+The payload file is unlinked immediately after creation. Only the inherited file
+descriptor remains visible to the helper. The existing startup status pipe is
+kept open through `launchctl` and the helper, then marked close-on-exec just
+before the final workload command is executed. This preserves the original
+startup contract: exec failures are reported before the runtime sends the process
+start acknowledgement.
+
+## Expected Behavior
+
+A healthy non-root workload process should report the target user from both
+identity and launchd context:
+
+```sh
+id
+launchctl manageruid
+launchctl managername
+```
+
+For an `admin` workload, `id` should show `uid=501(admin)`,
+`launchctl manageruid` should print `501`, and `launchctl managername` should
+print `Background` or another user-domain manager name. A process that shows
+`uid=501(admin)` but `launchctl manageruid` prints `0` is still running in the
+System bootstrap namespace.
+
+For keychain-sensitive build jobs, user-domain keychain commands should work
+without passing the keychain path to every tool:
+
+```sh
+security list-keychains
+security default-keychain
+security find-identity -v -p codesigning
+```
+
+The list should include the user's keychain entries rather than only
+`/Library/Keychains/System.keychain` and root's login keychain.
+
+## Operational Notes
+
+This runtime behavior does not install certificates or create build keychains.
+Workloads that need signing material still create and unlock their own keychain
+at build time. The runtime only ensures the process has the correct macOS user
+bootstrap context so framework defaults resolve against the workload user.
+
+If a signing job still cannot see identities, check these items in order:
+
+1. The process user from `id`.
+2. The launchd manager from `launchctl manageruid` and `launchctl managername`.
+3. The user keychain search list from `security list-keychains -d user`.
+4. The default search list from `security list-keychains`.
+5. The explicit identity result from `security find-identity -v -p codesigning <keychain-path>`.
+
+When the explicit keychain lookup succeeds but the default lookup fails, the
+process is usually not running in the expected user bootstrap namespace.


### PR DESCRIPTION
## Summary
- preserve workload-layer file ownership when materializing macOS image-backed workloads
- start non-root macOS workload processes in the target user bootstrap namespace before dropping privileges
- preserve exec startup error reporting through the internal helper path
- document the workload user bootstrap context and keychain visibility checks

## Fixes included
- prevent workload content such as /app from being rewritten as root-owned during image materialization
- make user-scoped launchd services and keychains visible to admin workload processes
- keep process credentials, HOME, USER, and LOGNAME aligned with the configured workload user

## Validation
- swift build --product container-macos-guest-agent
- swift build -c release --product container-macos-guest-agent
- image-backed workload ownership tests
- local refreshed image validation: admin workload reports launchctl manageruid=501 and security find-identity sees the imported signing identity without an explicit keychain path

## Notes
- Full MacOSGuestAgentTests build is blocked on this local SDK because the package dependency requires macOS 26 vmnet symbols. The release workflow runs on macos-26.