### PR TITLE
fix: configure effective DNS in macOS guests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -686,7 +686,10 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "RuntimeMacOSSidecarShared",
             ],
-            path: "Sources/Helpers/MacOSGuestAgent"
+            path: "Sources/Helpers/MacOSGuestAgent",
+            linkerSettings: [
+                .linkedFramework("SystemConfiguration")
+            ]
         ),
         .executableTarget(
             name: "container-macos-image-prepare",

--- a/Sources/ContainerResource/Container/ContainerConfiguration+MacOSGuestNetworking.swift
+++ b/Sources/ContainerResource/Container/ContainerConfiguration+MacOSGuestNetworking.swift
@@ -87,7 +87,7 @@ extension ContainerConfiguration {
             nameservers: nameservers,
             domain: dns.domain,
             searchDomains: dns.searchDomains,
-            options: []
+            options: dns.options
         )
     }
 

--- a/Sources/Helpers/MacOSGuestAgent/GuestNetworkConfigurator.swift
+++ b/Sources/Helpers/MacOSGuestAgent/GuestNetworkConfigurator.swift
@@ -25,116 +25,107 @@ struct GuestNetworkConfigurator {
     }
 
     let runCommand: @Sendable (_ executable: String, _ arguments: [String]) throws -> CommandResult
+    let applySystemConfiguration:
+        @Sendable (
+            _ interfaces: [GuestSystemNetworkConfigurator.InterfaceConfiguration],
+            _ primaryInterfaceIndex: Int,
+            _ dns: MacOSGuestDNSConfiguration?
+        ) throws -> GuestSystemNetworkConfigurator.Result
 
     init(
-        runCommand: @escaping @Sendable (_ executable: String, _ arguments: [String]) throws -> CommandResult = GuestNetworkConfigurator.runSystemCommand
+        runCommand: @escaping @Sendable (_ executable: String, _ arguments: [String]) throws -> CommandResult = GuestNetworkConfigurator.runSystemCommand,
+        applySystemConfiguration:
+            @escaping @Sendable (
+                _ interfaces: [GuestSystemNetworkConfigurator.InterfaceConfiguration],
+                _ primaryInterfaceIndex: Int,
+                _ dns: MacOSGuestDNSConfiguration?
+            ) throws -> GuestSystemNetworkConfigurator.Result = GuestSystemNetworkConfigurator.apply
     ) {
         self.runCommand = runCommand
+        self.applySystemConfiguration = applySystemConfiguration
     }
 
     func apply(_ request: MacOSGuestNetworkConfigurationRequest) throws -> MacOSGuestNetworkConfigurationResult {
         guard !request.interfaces.isEmpty else {
-            return .init(interfaces: [], dnsApplied: false)
+            return .init(interfaces: [], dnsApplied: false, effectiveDNS: nil)
         }
 
         let interfaceLookup = try Self.parseInterfaceNamesByMAC(
             from: runCommand("/sbin/ifconfig", ["-a"]).stdout
         )
 
-        var appliedInterfaces: [MacOSGuestAppliedNetworkInterface] = []
+        var resolvedInterfaces: [GuestSystemNetworkConfigurator.InterfaceConfiguration] = []
+        var effectiveMTUs: [String: UInt32] = [:]
         for interface in request.interfaces {
             let normalizedMAC = Self.normalizeMACAddress(interface.macAddress)
             guard let interfaceName = interfaceLookup[normalizedMAC] else {
                 throw Self.makeError("guest network interface not found for MAC \(interface.macAddress)")
             }
-            let effectiveMTU = try configureInterface(interfaceName: interfaceName, interface: interface)
-            appliedInterfaces.append(
+            effectiveMTUs[interfaceName] = try prepareInterface(
+                interfaceName: interfaceName,
+                requestedMTU: interface.mtu
+            )
+            resolvedInterfaces.append(
                 .init(
                     networkID: interface.networkID,
                     interfaceName: interfaceName,
                     macAddress: interface.macAddress,
-                    ipv4Address: "\(interface.ipv4Address)/\(interface.ipv4PrefixLength)",
+                    ipv4Address: interface.ipv4Address,
+                    ipv4PrefixLength: interface.ipv4PrefixLength,
+                    ipv4Gateway: interface.ipv4Gateway
+                )
+            )
+        }
+
+        let primaryIndex = min(max(request.primaryInterfaceIndex, 0), resolvedInterfaces.count - 1)
+        let effectiveConfiguration = try applySystemConfiguration(resolvedInterfaces, primaryIndex, request.dns)
+        guard effectiveConfiguration.interfaces.count == resolvedInterfaces.count else {
+            throw Self.makeError(
+                "SystemConfiguration returned \(effectiveConfiguration.interfaces.count) interfaces; expected \(resolvedInterfaces.count)"
+            )
+        }
+
+        var appliedInterfaces: [MacOSGuestAppliedNetworkInterface] = []
+        for effective in effectiveConfiguration.interfaces {
+            guard let effectiveMTU = effectiveMTUs[effective.interfaceName] else {
+                throw Self.makeError(
+                    "SystemConfiguration returned unexpected interface \(effective.interfaceName)"
+                )
+            }
+            appliedInterfaces.append(
+                .init(
+                    networkID: effective.networkID,
+                    interfaceName: effective.interfaceName,
+                    macAddress: effective.macAddress,
+                    ipv4Address: effective.ipv4Address,
                     effectiveMTU: effectiveMTU
                 )
             )
         }
 
-        let primaryIndex = min(max(request.primaryInterfaceIndex, 0), appliedInterfaces.count - 1)
-        try configureDefaultRoute(gateway: request.interfaces[primaryIndex].ipv4Gateway)
-
-        var warnings: [String] = []
-        let dnsApplied = try configureDNSIfNeeded(
-            request.dns,
-            primaryInterfaceName: appliedInterfaces[primaryIndex].interfaceName,
-            warnings: &warnings
+        return .init(
+            interfaces: appliedInterfaces,
+            dnsApplied: effectiveConfiguration.effectiveDNS != nil,
+            effectiveDNS: effectiveConfiguration.effectiveDNS
         )
-        return .init(interfaces: appliedInterfaces, dnsApplied: dnsApplied, warnings: warnings)
     }
 
-    private func configureInterface(
-        interfaceName: String,
-        interface: MacOSGuestNetworkInterfaceConfiguration
-    ) throws -> UInt32 {
-        var arguments = [
-            interfaceName,
-            "inet",
-            interface.ipv4Address,
-            "netmask",
-            Self.ipv4NetmaskString(prefixLength: interface.ipv4PrefixLength),
-        ]
-        if let mtu = interface.mtu {
-            arguments.append(contentsOf: ["mtu", String(mtu)])
+    private func prepareInterface(interfaceName: String, requestedMTU: UInt32?) throws -> UInt32 {
+        var arguments = [interfaceName]
+        if let requestedMTU {
+            arguments.append(contentsOf: ["mtu", String(requestedMTU)])
         }
         arguments.append("up")
-        _ = try run(
-            "/sbin/ifconfig",
-            arguments
-        )
+        _ = try run("/sbin/ifconfig", arguments)
+
         let output = try run("/sbin/ifconfig", [interfaceName]).stdout
         let effectiveMTU = try Self.parseInterfaceMTU(from: output, interfaceName: interfaceName)
-        if let requestedMTU = interface.mtu, effectiveMTU != requestedMTU {
+        if let requestedMTU, effectiveMTU != requestedMTU {
             throw Self.makeError(
                 "guest network interface \(interfaceName) MTU mismatch: requested \(requestedMTU), effective \(effectiveMTU)"
             )
         }
         return effectiveMTU
-    }
-
-    private func configureDefaultRoute(gateway: String) throws {
-        _ = try? runCommand("/sbin/route", ["-n", "delete", "default"])
-        _ = try run("/sbin/route", ["-n", "add", "default", gateway])
-    }
-
-    private func configureDNSIfNeeded(
-        _ dns: MacOSGuestDNSConfiguration?,
-        primaryInterfaceName: String,
-        warnings: inout [String]
-    ) throws -> Bool {
-        guard let dns else {
-            return false
-        }
-
-        if !dns.options.isEmpty {
-            warnings.append("dns options are not yet applied inside the macOS guest")
-        }
-
-        let servicesByInterface = try Self.parseNetworkServicesByDevice(
-            from: runCommand("/usr/sbin/networksetup", ["-listnetworkserviceorder"]).stdout
-        )
-        guard let serviceName = servicesByInterface[primaryInterfaceName] else {
-            throw Self.makeError("guest network service not found for interface \(primaryInterfaceName)")
-        }
-
-        let nameservers = dns.nameservers.isEmpty ? ["Empty"] : dns.nameservers
-        _ = try run("/usr/sbin/networksetup", ["-setdnsservers", serviceName] + nameservers)
-
-        var searchDomains = dns.searchDomains
-        if let domain = dns.domain, !domain.isEmpty, !searchDomains.contains(domain) {
-            searchDomains.insert(domain, at: 0)
-        }
-        let searchArgs = searchDomains.isEmpty ? ["Empty"] : searchDomains
-        _ = try run("/usr/sbin/networksetup", ["-setsearchdomains", serviceName] + searchArgs)
-        return true
     }
 
     private func run(_ executable: String, _ arguments: [String]) throws -> CommandResult {
@@ -192,58 +183,8 @@ struct GuestNetworkConfigurator {
         return mtu
     }
 
-    static func parseNetworkServicesByDevice(from serviceOrderOutput: String) throws -> [String: String] {
-        var result: [String: String] = [:]
-        var currentService: String?
-
-        for rawLine in serviceOrderOutput.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard !line.isEmpty else {
-                continue
-            }
-
-            if line.hasPrefix("("), let closing = line.firstIndex(of: ")") {
-                let service = line[line.index(after: closing)...].trimmingCharacters(in: .whitespaces)
-                if !service.isEmpty, !service.hasPrefix("(Hardware Port:") {
-                    currentService = service
-                    continue
-                }
-            }
-
-            guard
-                line.hasPrefix("(Hardware Port:"),
-                let deviceRange = line.range(of: "Device: ")
-            else {
-                continue
-            }
-
-            let deviceSuffix = line[deviceRange.upperBound...]
-            let device =
-                deviceSuffix
-                .replacingOccurrences(of: ")", with: "")
-                .trimmingCharacters(in: .whitespaces)
-            guard let currentService, !device.isEmpty else {
-                continue
-            }
-            result[device] = currentService
-        }
-
-        return result
-    }
-
     static func normalizeMACAddress(_ macAddress: String) -> String {
         macAddress.lowercased().replacingOccurrences(of: "-", with: ":")
-    }
-
-    static func ipv4NetmaskString(prefixLength: UInt8) -> String {
-        let bits = Int(prefixLength)
-        let value: UInt32 = bits == 0 ? 0 : ~UInt32(0) << (32 - bits)
-        return [
-            String((value >> 24) & 0xff),
-            String((value >> 16) & 0xff),
-            String((value >> 8) & 0xff),
-            String(value & 0xff),
-        ].joined(separator: ".")
     }
 
     private static func runSystemCommand(_ executable: String, _ arguments: [String]) throws -> CommandResult {

--- a/Sources/Helpers/MacOSGuestAgent/GuestSystemNetworkConfigurator.swift
+++ b/Sources/Helpers/MacOSGuestAgent/GuestSystemNetworkConfigurator.swift
@@ -1,0 +1,591 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import RuntimeMacOSSidecarShared
+import SystemConfiguration
+
+struct GuestSystemNetworkConfigurator {
+    struct InterfaceConfiguration: Sendable, Equatable {
+        let networkID: String
+        let interfaceName: String
+        let macAddress: String
+        let ipv4Address: String
+        let ipv4PrefixLength: UInt8
+        let ipv4Gateway: String
+    }
+
+    struct AppliedInterface: Sendable, Equatable {
+        let networkID: String
+        let interfaceName: String
+        let macAddress: String
+        let ipv4Address: String
+    }
+
+    struct Result: Sendable, Equatable {
+        let interfaces: [AppliedInterface]
+        let effectiveDNS: MacOSGuestEffectiveDNSConfiguration?
+    }
+
+    private struct ProtocolSnapshot {
+        let configuration: CFDictionary?
+        let enabled: Bool
+    }
+
+    private struct ServiceSnapshot {
+        let service: SCNetworkService
+        let created: Bool
+        let addedToSet: Bool
+        let enabled: Bool
+        let ipv4: ProtocolSnapshot?
+        let dns: ProtocolSnapshot?
+    }
+
+    private struct ConfiguredInterface {
+        let request: InterfaceConfiguration
+        let serviceID: String
+        let isPrimary: Bool
+    }
+
+    static func apply(
+        interfaces: [InterfaceConfiguration],
+        primaryInterfaceIndex: Int,
+        dns: MacOSGuestDNSConfiguration?
+    ) throws -> Result {
+        guard !interfaces.isEmpty else {
+            return Result(interfaces: [], effectiveDNS: nil)
+        }
+
+        guard
+            let preferences = SCPreferencesCreate(
+                nil,
+                "container-macos-guest-agent" as CFString,
+                nil
+            )
+        else {
+            throw makeSystemConfigurationError("create preferences session")
+        }
+        guard lockPreferences(preferences) else {
+            throw makeSystemConfigurationError("lock network preferences")
+        }
+        defer {
+            SCPreferencesUnlock(preferences)
+        }
+
+        let setResult = try currentNetworkSet(in: preferences)
+        let networkSet = setResult.set
+        var snapshots: [ServiceSnapshot] = []
+
+        do {
+            let primaryIndex = min(max(primaryInterfaceIndex, 0), interfaces.count - 1)
+            var configured: [ConfiguredInterface] = []
+
+            for (index, interface) in interfaces.enumerated() {
+                let serviceResult = try networkService(
+                    for: interface.interfaceName,
+                    preferences: preferences,
+                    networkSet: networkSet
+                )
+                let service = serviceResult.service
+                snapshots.append(
+                    ServiceSnapshot(
+                        service: service,
+                        created: serviceResult.created,
+                        addedToSet: serviceResult.addedToSet,
+                        enabled: SCNetworkServiceGetEnabled(service),
+                        ipv4: protocolSnapshot(service: service, type: kSCNetworkProtocolTypeIPv4),
+                        dns: protocolSnapshot(service: service, type: kSCNetworkProtocolTypeDNS)
+                    )
+                )
+
+                guard SCNetworkServiceSetEnabled(service, true) else {
+                    throw makeSystemConfigurationError("enable network service for \(interface.interfaceName)")
+                }
+                try setProtocolConfiguration(
+                    service: service,
+                    type: kSCNetworkProtocolTypeIPv4,
+                    configuration: ipv4ConfigurationDictionary(
+                        for: interface,
+                        includeDefaultRoute: index == primaryIndex
+                    ),
+                    enabled: true
+                )
+
+                if index == primaryIndex, let dns {
+                    try setProtocolConfiguration(
+                        service: service,
+                        type: kSCNetworkProtocolTypeDNS,
+                        configuration: dnsConfigurationDictionary(for: dns),
+                        enabled: true
+                    )
+                } else if dns != nil {
+                    try setProtocolConfiguration(
+                        service: service,
+                        type: kSCNetworkProtocolTypeDNS,
+                        configuration: [:],
+                        enabled: false
+                    )
+                }
+
+                guard let serviceID = SCNetworkServiceGetServiceID(service) as String? else {
+                    throw makeError("network service for \(interface.interfaceName) has no service identifier")
+                }
+                configured.append(
+                    ConfiguredInterface(
+                        request: interface,
+                        serviceID: serviceID,
+                        isPrimary: index == primaryIndex
+                    )
+                )
+            }
+
+            guard SCPreferencesCommitChanges(preferences) else {
+                throw makeSystemConfigurationError("commit network preferences")
+            }
+            guard SCPreferencesApplyChanges(preferences) else {
+                throw makeSystemConfigurationError("apply network preferences")
+            }
+
+            return try waitForEffectiveConfiguration(
+                configured,
+                primaryInterfaceIndex: primaryIndex,
+                dns: dns
+            )
+        } catch {
+            rollback(
+                snapshots: snapshots,
+                networkSet: networkSet,
+                removeNetworkSet: setResult.created,
+                preferences: preferences
+            )
+            throw error
+        }
+    }
+
+    static func ipv4ConfigurationDictionary(
+        for interface: InterfaceConfiguration,
+        includeDefaultRoute: Bool = true
+    ) -> [String: Any] {
+        var configuration: [String: Any] = [
+            kSCPropNetIPv4ConfigMethod as String: kSCValNetIPv4ConfigMethodManual as String,
+            kSCPropNetIPv4Addresses as String: [interface.ipv4Address],
+            kSCPropNetIPv4SubnetMasks as String: [ipv4NetmaskString(prefixLength: interface.ipv4PrefixLength)],
+        ]
+        if includeDefaultRoute {
+            configuration[kSCPropNetIPv4Router as String] = interface.ipv4Gateway
+        }
+        return configuration
+    }
+
+    static func dnsConfigurationDictionary(
+        for dns: MacOSGuestDNSConfiguration
+    ) -> [String: Any] {
+        var configuration: [String: Any] = [
+            kSCPropNetDNSServerAddresses as String: dns.nameservers,
+            kSCPropNetDNSSearchDomains as String: dns.searchDomains,
+        ]
+        if let domain = dns.domain, !domain.isEmpty {
+            configuration[kSCPropNetDNSDomainName as String] = domain
+        }
+        if !dns.options.isEmpty {
+            configuration[kSCPropNetDNSOptions as String] = dns.options.joined(separator: " ")
+        }
+        return configuration
+    }
+
+    static func effectiveDNSConfiguration(
+        serviceID: String,
+        interfaceName: String,
+        requested: MacOSGuestDNSConfiguration,
+        properties: NSDictionary
+    ) throws -> MacOSGuestEffectiveDNSConfiguration {
+        let nameservers = stringArray(properties[kSCPropNetDNSServerAddresses as String])
+        let searchDomains = stringArray(properties[kSCPropNetDNSSearchDomains as String])
+        let domain = nonEmptyString(properties[kSCPropNetDNSDomainName as String])
+        let options =
+            (properties[kSCPropNetDNSOptions as String] as? String)?
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init) ?? []
+
+        guard nameservers == requested.nameservers else {
+            throw makeError("active DNS nameserver mismatch: requested \(requested.nameservers), effective \(nameservers)")
+        }
+        guard searchDomains == requested.searchDomains else {
+            throw makeError("active DNS search domain mismatch: requested \(requested.searchDomains), effective \(searchDomains)")
+        }
+        guard domain == nonEmptyString(requested.domain) else {
+            throw makeError("active DNS domain mismatch: requested \(requested.domain ?? "none"), effective \(domain ?? "none")")
+        }
+        guard options == requested.options else {
+            throw makeError("active DNS option mismatch: requested \(requested.options), effective \(options)")
+        }
+
+        return MacOSGuestEffectiveDNSConfiguration(
+            serviceID: serviceID,
+            interfaceName: interfaceName,
+            nameservers: nameservers,
+            domain: domain,
+            searchDomains: searchDomains,
+            options: options
+        )
+    }
+
+    private static func lockPreferences(_ preferences: SCPreferences) -> Bool {
+        for attempt in 0..<50 {
+            if SCPreferencesLock(preferences, false) {
+                return true
+            }
+            if attempt < 49 {
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+        }
+        return false
+    }
+
+    private static func currentNetworkSet(
+        in preferences: SCPreferences
+    ) throws -> (set: SCNetworkSet, created: Bool) {
+        if let current = SCNetworkSetCopyCurrent(preferences) {
+            return (current, false)
+        }
+        guard let created = SCNetworkSetCreate(preferences) else {
+            throw makeSystemConfigurationError("create network set")
+        }
+        guard SCNetworkSetSetName(created, "Container" as CFString) else {
+            throw makeSystemConfigurationError("name network set")
+        }
+        guard SCNetworkSetSetCurrent(created) else {
+            throw makeSystemConfigurationError("select network set")
+        }
+        return (created, true)
+    }
+
+    private static func networkService(
+        for interfaceName: String,
+        preferences: SCPreferences,
+        networkSet: SCNetworkSet
+    ) throws -> (service: SCNetworkService, created: Bool, addedToSet: Bool) {
+        let services = (SCNetworkServiceCopyAll(preferences) as NSArray?) ?? []
+        let setServices = (SCNetworkSetCopyServices(networkSet) as NSArray?) ?? []
+        let setServiceIDs = Set(
+            setServices.compactMap { value -> String? in
+                let service = value as! SCNetworkService
+                return SCNetworkServiceGetServiceID(service) as String?
+            }
+        )
+        let setServiceNames = Set(
+            setServices.compactMap { value -> String? in
+                let service = value as! SCNetworkService
+                return SCNetworkServiceGetName(service) as String?
+            }
+        )
+        let matchingServices = services.compactMap { value -> SCNetworkService? in
+            let service = value as! SCNetworkService
+            guard
+                let interface = SCNetworkServiceGetInterface(service),
+                SCNetworkInterfaceGetBSDName(interface) as String? == interfaceName
+            else {
+                return nil
+            }
+            return service
+        }
+
+        let existing =
+            matchingServices.first {
+                guard let serviceID = SCNetworkServiceGetServiceID($0) as String? else {
+                    return false
+                }
+                return setServiceIDs.contains(serviceID)
+            } ?? matchingServices.first
+
+        let service: SCNetworkService
+        let created: Bool
+        if let existing {
+            service = existing
+            created = false
+        } else {
+            let availableInterfaces = SCNetworkInterfaceCopyAll() as NSArray
+            guard
+                let interface = availableInterfaces.map({ $0 as! SCNetworkInterface }).first(where: {
+                    SCNetworkInterfaceGetBSDName($0) as String? == interfaceName
+                })
+            else {
+                throw makeError("SystemConfiguration interface not found for \(interfaceName)")
+            }
+            guard let newService = SCNetworkServiceCreate(preferences, interface) else {
+                throw makeSystemConfigurationError("create network service for \(interfaceName)")
+            }
+            guard SCNetworkServiceEstablishDefaultConfiguration(newService) else {
+                throw makeSystemConfigurationError("establish network service for \(interfaceName)")
+            }
+            service = newService
+            created = true
+
+            guard let serviceID = SCNetworkServiceGetServiceID(service) as String? else {
+                throw makeError("new network service for \(interfaceName) has no service identifier")
+            }
+            let baseName = "Container \(interfaceName)"
+            let serviceName = setServiceNames.contains(baseName) ? "\(baseName) \(serviceID.prefix(8))" : baseName
+            guard SCNetworkServiceSetName(service, serviceName as CFString) else {
+                throw makeSystemConfigurationError("name network service for \(interfaceName)")
+            }
+        }
+
+        let serviceID = SCNetworkServiceGetServiceID(service) as String?
+        let isInSet = serviceID.map(setServiceIDs.contains) ?? false
+        if !isInSet, !SCNetworkSetAddService(networkSet, service) {
+            throw makeSystemConfigurationError("add network service for \(interfaceName) to current set")
+        }
+        return (service, created, !isInSet)
+    }
+
+    private static func setProtocolConfiguration(
+        service: SCNetworkService,
+        type: CFString,
+        configuration: [String: Any],
+        enabled: Bool
+    ) throws {
+        if SCNetworkServiceCopyProtocol(service, type) == nil,
+            !SCNetworkServiceAddProtocolType(service, type)
+        {
+            throw makeSystemConfigurationError("add \(type) network protocol")
+        }
+        guard let networkProtocol = SCNetworkServiceCopyProtocol(service, type) else {
+            throw makeSystemConfigurationError("load \(type) network protocol")
+        }
+        guard SCNetworkProtocolSetConfiguration(networkProtocol, configuration as CFDictionary) else {
+            throw makeSystemConfigurationError("configure \(type) network protocol")
+        }
+        guard SCNetworkProtocolSetEnabled(networkProtocol, enabled) else {
+            throw makeSystemConfigurationError("set \(type) network protocol state")
+        }
+    }
+
+    private static func protocolSnapshot(
+        service: SCNetworkService,
+        type: CFString
+    ) -> ProtocolSnapshot? {
+        guard let networkProtocol = SCNetworkServiceCopyProtocol(service, type) else {
+            return nil
+        }
+        return ProtocolSnapshot(
+            configuration: SCNetworkProtocolGetConfiguration(networkProtocol),
+            enabled: SCNetworkProtocolGetEnabled(networkProtocol)
+        )
+    }
+
+    private static func rollback(
+        snapshots: [ServiceSnapshot],
+        networkSet: SCNetworkSet,
+        removeNetworkSet: Bool,
+        preferences: SCPreferences
+    ) {
+        for snapshot in snapshots.reversed() {
+            if snapshot.created {
+                _ = SCNetworkServiceRemove(snapshot.service)
+                continue
+            }
+            restoreProtocol(snapshot.ipv4, service: snapshot.service, type: kSCNetworkProtocolTypeIPv4)
+            restoreProtocol(snapshot.dns, service: snapshot.service, type: kSCNetworkProtocolTypeDNS)
+            _ = SCNetworkServiceSetEnabled(snapshot.service, snapshot.enabled)
+            if snapshot.addedToSet {
+                _ = SCNetworkSetRemoveService(networkSet, snapshot.service)
+            }
+        }
+        if removeNetworkSet {
+            _ = SCNetworkSetRemove(networkSet)
+        }
+        _ = SCPreferencesCommitChanges(preferences)
+        _ = SCPreferencesApplyChanges(preferences)
+    }
+
+    private static func restoreProtocol(
+        _ snapshot: ProtocolSnapshot?,
+        service: SCNetworkService,
+        type: CFString
+    ) {
+        guard let snapshot else {
+            _ = SCNetworkServiceRemoveProtocolType(service, type)
+            return
+        }
+        guard let networkProtocol = SCNetworkServiceCopyProtocol(service, type) else {
+            return
+        }
+        _ = SCNetworkProtocolSetConfiguration(networkProtocol, snapshot.configuration)
+        _ = SCNetworkProtocolSetEnabled(networkProtocol, snapshot.enabled)
+    }
+
+    private static func waitForEffectiveConfiguration(
+        _ configured: [ConfiguredInterface],
+        primaryInterfaceIndex: Int,
+        dns: MacOSGuestDNSConfiguration?
+    ) throws -> Result {
+        guard
+            let store = SCDynamicStoreCreate(
+                nil,
+                "container-macos-guest-agent-validation" as CFString,
+                nil,
+                nil
+            )
+        else {
+            throw makeSystemConfigurationError("create dynamic store session")
+        }
+
+        var lastMismatch = "active network state was not published"
+        for attempt in 0..<50 {
+            do {
+                let appliedInterfaces = try configured.map {
+                    try readEffectiveIPv4($0, store: store)
+                }
+                let effectiveDNS: MacOSGuestEffectiveDNSConfiguration?
+                if let dns {
+                    effectiveDNS = try readEffectiveDNS(
+                        configured[primaryInterfaceIndex],
+                        requested: dns,
+                        store: store
+                    )
+                } else {
+                    effectiveDNS = nil
+                }
+                return Result(interfaces: appliedInterfaces, effectiveDNS: effectiveDNS)
+            } catch {
+                lastMismatch = error.localizedDescription
+            }
+
+            if attempt < 49 {
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+        }
+        throw makeError("active SystemConfiguration state did not match the request: \(lastMismatch)")
+    }
+
+    private static func readEffectiveIPv4(
+        _ configured: ConfiguredInterface,
+        store: SCDynamicStore
+    ) throws -> AppliedInterface {
+        let key = "State:/Network/Service/\(configured.serviceID)/IPv4"
+        guard let dictionary = dynamicStoreDictionary(store: store, key: key) else {
+            throw makeError("active IPv4 state is missing for service \(configured.serviceID)")
+        }
+
+        let request = configured.request
+        let addresses = stringArray(dictionary[kSCPropNetIPv4Addresses as String])
+        let subnetMasks = stringArray(dictionary[kSCPropNetIPv4SubnetMasks as String])
+        let router = dictionary[kSCPropNetIPv4Router as String] as? String
+        let interfaceName = dictionary[kSCPropInterfaceName as String] as? String ?? request.interfaceName
+        let expectedMask = ipv4NetmaskString(prefixLength: request.ipv4PrefixLength)
+
+        guard addresses.contains(request.ipv4Address) else {
+            throw makeError("active IPv4 address mismatch for \(request.interfaceName): \(addresses)")
+        }
+        guard subnetMasks.contains(expectedMask) else {
+            throw makeError("active IPv4 subnet mask mismatch for \(request.interfaceName): \(subnetMasks)")
+        }
+        if configured.isPrimary {
+            guard router == request.ipv4Gateway else {
+                throw makeError("active IPv4 router mismatch for \(request.interfaceName): \(router ?? "missing")")
+            }
+        } else if let router {
+            throw makeError("secondary interface \(request.interfaceName) unexpectedly installed router \(router)")
+        }
+        guard interfaceName == request.interfaceName else {
+            throw makeError("active interface mismatch for service \(configured.serviceID): \(interfaceName)")
+        }
+
+        return AppliedInterface(
+            networkID: request.networkID,
+            interfaceName: interfaceName,
+            macAddress: request.macAddress,
+            ipv4Address: "\(request.ipv4Address)/\(request.ipv4PrefixLength)"
+        )
+    }
+
+    private static func readEffectiveDNS(
+        _ configured: ConfiguredInterface,
+        requested: MacOSGuestDNSConfiguration,
+        store: SCDynamicStore
+    ) throws -> MacOSGuestEffectiveDNSConfiguration {
+        let key = "State:/Network/Service/\(configured.serviceID)/DNS"
+        guard let dictionary = dynamicStoreDictionary(store: store, key: key) else {
+            throw makeError("active DNS state is missing for service \(configured.serviceID)")
+        }
+
+        return try effectiveDNSConfiguration(
+            serviceID: configured.serviceID,
+            interfaceName: configured.request.interfaceName,
+            requested: requested,
+            properties: dictionary
+        )
+    }
+
+    private static func dynamicStoreDictionary(
+        store: SCDynamicStore,
+        key: String
+    ) -> NSDictionary? {
+        guard let value = SCDynamicStoreCopyValue(store, key as CFString) else {
+            return nil
+        }
+        return value as? NSDictionary
+    }
+
+    private static func stringArray(_ value: Any?) -> [String] {
+        (value as? [String]) ?? []
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let value = value as? String, !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func nonEmptyString(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    private static func ipv4NetmaskString(prefixLength: UInt8) -> String {
+        let bits = Int(prefixLength)
+        let value: UInt32 = bits == 0 ? 0 : ~UInt32(0) << (32 - bits)
+        return [
+            String((value >> 24) & 0xff),
+            String((value >> 16) & 0xff),
+            String((value >> 8) & 0xff),
+            String(value & 0xff),
+        ].joined(separator: ".")
+    }
+
+    private static func makeSystemConfigurationError(_ action: String) -> NSError {
+        let code = SCError()
+        return NSError(
+            domain: "container.macos.guest-agent.system-configuration",
+            code: Int(code),
+            userInfo: [
+                NSLocalizedDescriptionKey: "failed to \(action): \(String(cString: SCErrorString(code)))"
+            ]
+        )
+    }
+
+    private static func makeError(_ message: String) -> NSError {
+        NSError(
+            domain: "container.macos.guest-agent.system-configuration",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+}

--- a/Sources/Helpers/RuntimeMacOSSidecar/MacOSGuestNetworkBootstrap.swift
+++ b/Sources/Helpers/RuntimeMacOSSidecar/MacOSGuestNetworkBootstrap.swift
@@ -94,6 +94,73 @@ enum MacOSGuestNetworkBootstrap {
                 )
             }
         }
+
+        guard let requestedDNS = request.dns else {
+            return
+        }
+        guard !request.interfaces.isEmpty else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "guest DNS configuration requires a primary network interface"
+            )
+        }
+        guard result.dnsApplied, let effectiveDNS = result.effectiveDNS else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "guest did not report an effective DNS resolver"
+            )
+        }
+        guard !effectiveDNS.serviceID.isEmpty else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "guest effective DNS resolver is missing its SystemConfiguration service identifier"
+            )
+        }
+
+        let primaryIndex = min(max(request.primaryInterfaceIndex, 0), request.interfaces.count - 1)
+        let primary = request.interfaces[primaryIndex]
+        guard
+            let appliedPrimary = result.interfaces.first(where: {
+                $0.networkID == primary.networkID
+                    && $0.macAddress.caseInsensitiveCompare(primary.macAddress) == .orderedSame
+            }),
+            effectiveDNS.interfaceName == appliedPrimary.interfaceName
+        else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "guest effective DNS resolver is not attached to the primary interface"
+            )
+        }
+
+        guard effectiveDNS.nameservers == requestedDNS.nameservers else {
+            throw ContainerizationError(
+                .invalidState,
+                message:
+                    "guest DNS nameserver mismatch: requested \(requestedDNS.nameservers), effective \(effectiveDNS.nameservers)"
+            )
+        }
+        let requestedDomain = normalizedDNSDomain(requestedDNS.domain)
+        guard effectiveDNS.domain == requestedDomain else {
+            throw ContainerizationError(
+                .invalidState,
+                message:
+                    "guest DNS domain mismatch: requested \(requestedDomain ?? "none"), effective \(effectiveDNS.domain ?? "none")"
+            )
+        }
+        guard effectiveDNS.searchDomains == requestedDNS.searchDomains else {
+            throw ContainerizationError(
+                .invalidState,
+                message:
+                    "guest DNS search domain mismatch: requested \(requestedDNS.searchDomains), effective \(effectiveDNS.searchDomains)"
+            )
+        }
+        guard effectiveDNS.options == requestedDNS.options else {
+            throw ContainerizationError(
+                .invalidState,
+                message:
+                    "guest DNS option mismatch: requested \(requestedDNS.options), effective \(effectiveDNS.options)"
+            )
+        }
     }
 
     private static func makeDNSConfiguration(
@@ -107,7 +174,14 @@ enum MacOSGuestNetworkBootstrap {
             nameservers: dns.nameservers,
             domain: dns.domain,
             searchDomains: dns.searchDomains,
-            options: []
+            options: dns.options
         )
+    }
+
+    private static func normalizedDNSDomain(_ domain: String?) -> String? {
+        guard let domain, !domain.isEmpty else {
+            return nil
+        }
+        return domain
     }
 }

--- a/Sources/Helpers/RuntimeMacOSSidecar/RuntimeMacOSSidecar.swift
+++ b/Sources/Helpers/RuntimeMacOSSidecar/RuntimeMacOSSidecar.swift
@@ -662,6 +662,9 @@ actor MacOSSidecarService {
                     metadata: [
                         "interfaces": "\(result.interfaces.count)",
                         "dns_applied": "\(result.dnsApplied)",
+                        "dns_service_id": "\(result.effectiveDNS?.serviceID ?? "none")",
+                        "dns_interface": "\(result.effectiveDNS?.interfaceName ?? "none")",
+                        "dns_nameservers": "\(result.effectiveDNS?.nameservers.joined(separator: ",") ?? "none")",
                     ]
                 )
                 for warning in result.warnings {

--- a/Sources/Helpers/RuntimeMacOSSidecarShared/SidecarGuestNetworkingProtocol.swift
+++ b/Sources/Helpers/RuntimeMacOSSidecarShared/SidecarGuestNetworkingProtocol.swift
@@ -101,18 +101,47 @@ public struct MacOSGuestAppliedNetworkInterface: Codable, Sendable, Equatable {
     }
 }
 
+public struct MacOSGuestEffectiveDNSConfiguration: Codable, Sendable, Equatable {
+    public let serviceID: String
+    public let interfaceName: String
+    public let nameservers: [String]
+    public let domain: String?
+    public let searchDomains: [String]
+    public let options: [String]
+
+    public init(
+        serviceID: String,
+        interfaceName: String,
+        nameservers: [String],
+        domain: String?,
+        searchDomains: [String],
+        options: [String]
+    ) {
+        self.serviceID = serviceID
+        self.interfaceName = interfaceName
+        self.nameservers = nameservers
+        self.domain = domain
+        self.searchDomains = searchDomains
+        self.options = options
+    }
+}
+
 public struct MacOSGuestNetworkConfigurationResult: Codable, Sendable, Equatable {
     public let interfaces: [MacOSGuestAppliedNetworkInterface]
+    /// Retained for compatibility with sidecars that predate effective DNS reporting.
     public let dnsApplied: Bool
+    public let effectiveDNS: MacOSGuestEffectiveDNSConfiguration?
     public let warnings: [String]
 
     public init(
         interfaces: [MacOSGuestAppliedNetworkInterface],
         dnsApplied: Bool,
+        effectiveDNS: MacOSGuestEffectiveDNSConfiguration? = nil,
         warnings: [String] = []
     ) {
         self.interfaces = interfaces
         self.dnsApplied = dnsApplied
+        self.effectiveDNS = effectiveDNS
         self.warnings = warnings
     }
 }

--- a/Sources/Services/ContainerAPIService/Client/Utility.swift
+++ b/Sources/Services/ContainerAPIService/Client/Utility.swift
@@ -410,7 +410,6 @@ public struct Utility {
                 return (override.networks, sanitizeMacOSGuestDNS(dns))
             }
 
-            try validateMacOSGuestDNSOptions(management.dns.options)
             let domain = management.dns.domain ?? dnsDomain
             return (
                 override.networks,
@@ -418,7 +417,7 @@ public struct Utility {
                     nameservers: management.dns.nameservers,
                     domain: domain,
                     searchDomains: management.dns.searchDomains,
-                    options: []
+                    options: management.dns.options
                 )
             )
         }
@@ -460,7 +459,6 @@ public struct Utility {
             return (attachments, nil)
         }
 
-        try validateMacOSGuestDNSOptions(management.dns.options)
         let domain = management.dns.domain ?? dnsDomain
         return (
             attachments,
@@ -468,18 +466,9 @@ public struct Utility {
                 nameservers: management.dns.nameservers,
                 domain: domain,
                 searchDomains: management.dns.searchDomains,
-                options: []
+                options: management.dns.options
             )
         )
-    }
-
-    private static func validateMacOSGuestDNSOptions(_ options: [String]) throws {
-        guard options.isEmpty else {
-            throw ContainerizationError(
-                .unsupported,
-                message: "--dns-option is not supported for --os darwin"
-            )
-        }
     }
 
     private static func sanitizeMacOSGuestDNS(
@@ -489,7 +478,7 @@ public struct Utility {
             nameservers: dns.nameservers,
             domain: dns.domain,
             searchDomains: dns.searchDomains,
-            options: []
+            options: dns.options
         )
     }
 

--- a/Tests/ContainerAPIClientTests/UtilityTests.swift
+++ b/Tests/ContainerAPIClientTests/UtilityTests.swift
@@ -221,7 +221,7 @@ struct UtilityTests {
         #expect(resolvedDNS.nameservers == ["8.8.8.8"])
         #expect(resolvedDNS.domain == "example.com")
         #expect(resolvedDNS.searchDomains == ["svc.example.com"])
-        #expect(resolvedDNS.options.isEmpty)
+        #expect(resolvedDNS.options == ["debug"])
     }
 
     @Test("macOS guest networking override falls back to supported management DNS flags")
@@ -346,18 +346,20 @@ struct UtilityTests {
         }
     }
 
-    @Test("macOS guest networking rejects unsupported DNS options")
-    func testResolveMacOSGuestNetworkingRejectsDNSOptions() throws {
+    @Test("macOS guest networking preserves DNS options")
+    func testResolveMacOSGuestNetworkingPreservesDNSOptions() throws {
         var management = try Flags.Management.parse([])
         management.dns.options = ["ndots:2"]
 
-        #expect(throws: ContainerizationError.self) {
-            _ = try Utility.resolveMacOSGuestNetworking(
+        let resolved = try #require(
+            try Utility.resolveMacOSGuestNetworking(
                 containerID: "macos-guest",
                 management: management,
                 override: nil
             )
-        }
+        )
+
+        #expect(resolved.dns?.options == ["ndots:2"])
     }
 
     @Test("macOS guest networking rejects multiple CLI network attachments")

--- a/Tests/ContainerResourceTests/ContainerConfigurationMacOSTests.swift
+++ b/Tests/ContainerResourceTests/ContainerConfigurationMacOSTests.swift
@@ -294,7 +294,7 @@ struct ContainerConfigurationMacOSTests {
                     nameservers: ["9.9.9.9"],
                     domain: "example.internal",
                     searchDomains: ["svc.example.internal"],
-                    options: []
+                    options: ["ndots:2"]
                 ))
     }
 

--- a/Tests/MacOSGuestAgentTests/GuestNetworkConfiguratorTests.swift
+++ b/Tests/MacOSGuestAgentTests/GuestNetworkConfiguratorTests.swift
@@ -52,24 +52,7 @@ struct GuestNetworkConfiguratorTests {
     }
 
     @Test
-    func parsesNetworkServiceOrderByDevice() throws {
-        let output = """
-            An asterisk (*) denotes that a network service is disabled.
-            (1) Wi-Fi
-            (Hardware Port: Wi-Fi, Device: en0)
-
-            (2) USB LAN
-            (Hardware Port: USB 10/100/1000 LAN, Device: en7)
-            """
-
-        let mapping = try GuestNetworkConfigurator.parseNetworkServicesByDevice(from: output)
-
-        #expect(mapping["en0"] == "Wi-Fi")
-        #expect(mapping["en7"] == "USB LAN")
-    }
-
-    @Test
-    func appliesDomainAsFirstSearchDomainAndWarnsAboutUnsupportedOptions() throws {
+    func appliesNetworkThroughSystemConfigurationAndReportsEffectiveDNS() throws {
         let request = MacOSGuestNetworkConfigurationRequest(
             interfaces: [
                 .init(
@@ -91,50 +74,148 @@ struct GuestNetworkConfiguratorTests {
         )
 
         let recorder = CommandRecorder()
-        let configurator = GuestNetworkConfigurator { executable, arguments in
-            recorder.record(executable: executable, arguments: arguments)
-            switch (executable, arguments) {
-            case ("/sbin/ifconfig", ["-a"]):
-                return .init(
-                    stdout: """
-                        en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1500
-                        \tether 02:42:ac:11:00:02
-                        """,
-                    stderr: "",
-                    exitCode: 0
-                )
-            case ("/sbin/ifconfig", ["en0"]):
-                return .init(
-                    stdout: "en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1450\n",
-                    stderr: "",
-                    exitCode: 0
-                )
-            case ("/usr/sbin/networksetup", ["-listnetworkserviceorder"]):
-                return .init(
-                    stdout: """
-                        (1) Ethernet
-                        (Hardware Port: Ethernet, Device: en0)
-                        """,
-                    stderr: "",
-                    exitCode: 0
-                )
-            default:
-                return .init(stdout: "", stderr: "", exitCode: 0)
+        let systemRecorder = SystemConfigurationRecorder()
+        let configurator = GuestNetworkConfigurator(
+            runCommand: { executable, arguments in
+                recorder.record(executable: executable, arguments: arguments)
+                switch (executable, arguments) {
+                case ("/sbin/ifconfig", ["-a"]):
+                    return .init(
+                        stdout: """
+                            en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1500
+                            \tether 02:42:ac:11:00:02
+                            """,
+                        stderr: "",
+                        exitCode: 0
+                    )
+                case ("/sbin/ifconfig", ["en0"]):
+                    return .init(
+                        stdout: "en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1450\n",
+                        stderr: "",
+                        exitCode: 0
+                    )
+                default:
+                    return .init(stdout: "", stderr: "", exitCode: 0)
+                }
+            },
+            applySystemConfiguration: { interfaces, primaryIndex, dns in
+                systemRecorder.record(interfaces: interfaces, primaryIndex: primaryIndex, dns: dns)
+                return Self.makeSystemConfigurationResult(interfaces: interfaces, dns: dns)
             }
-        }
+        )
 
         let result = try configurator.apply(request)
 
         #expect(result.dnsApplied)
-        #expect(result.warnings == ["dns options are not yet applied inside the macOS guest"])
+        #expect(result.warnings.isEmpty)
+        #expect(result.effectiveDNS?.serviceID == "service-en0")
+        #expect(result.effectiveDNS?.interfaceName == "en0")
+        #expect(result.effectiveDNS?.domain == "cluster.local")
+        #expect(result.effectiveDNS?.searchDomains == ["svc.cluster.local"])
+        #expect(result.effectiveDNS?.options == ["ndots:5"])
         #expect(result.interfaces[0].effectiveMTU == 1_450)
+
+        let invocation = try #require(systemRecorder.invocation())
+        #expect(invocation.primaryIndex == 0)
+        #expect(invocation.interfaces[0].interfaceName == "en0")
+        #expect(invocation.interfaces[0].ipv4Address == "192.168.64.2")
+        #expect(invocation.dns?.options == ["ndots:5"])
+
         let commands = recorder.commands()
         #expect(
             commands.contains {
                 $0.executable == "/sbin/ifconfig"
-                    && $0.arguments == ["en0", "inet", "192.168.64.2", "netmask", "255.255.255.0", "mtu", "1450", "up"]
+                    && $0.arguments == ["en0", "mtu", "1450", "up"]
             })
-        #expect(commands.contains { $0.executable == "/usr/sbin/networksetup" && $0.arguments == ["-setsearchdomains", "Ethernet", "cluster.local", "svc.cluster.local"] })
+        #expect(!commands.contains { $0.executable == "/usr/sbin/networksetup" })
+        #expect(!commands.contains { $0.executable == "/sbin/route" })
+    }
+
+    @Test
+    func buildsManualIPv4AndDNSProtocolConfiguration() throws {
+        let interface = GuestSystemNetworkConfigurator.InterfaceConfiguration(
+            networkID: "default",
+            interfaceName: "en0",
+            macAddress: "02:42:ac:11:00:02",
+            ipv4Address: "192.168.64.2",
+            ipv4PrefixLength: 24,
+            ipv4Gateway: "192.168.64.1"
+        )
+        let ipv4 = GuestSystemNetworkConfigurator.ipv4ConfigurationDictionary(for: interface)
+        let dns = GuestSystemNetworkConfigurator.dnsConfigurationDictionary(
+            for: .init(
+                nameservers: ["10.96.0.10"],
+                domain: "cluster.local",
+                searchDomains: ["default.svc.cluster.local", "svc.cluster.local"],
+                options: ["ndots:5", "timeout:2"]
+            )
+        )
+
+        #expect(ipv4["ConfigMethod"] as? String == "Manual")
+        #expect(ipv4["Addresses"] as? [String] == ["192.168.64.2"])
+        #expect(ipv4["SubnetMasks"] as? [String] == ["255.255.255.0"])
+        #expect(ipv4["Router"] as? String == "192.168.64.1")
+        #expect(
+            GuestSystemNetworkConfigurator.ipv4ConfigurationDictionary(
+                for: interface,
+                includeDefaultRoute: false
+            )["Router"] == nil
+        )
+        #expect(dns["ServerAddresses"] as? [String] == ["10.96.0.10"])
+        #expect(dns["DomainName"] as? String == "cluster.local")
+        #expect(dns["SearchDomains"] as? [String] == ["default.svc.cluster.local", "svc.cluster.local"])
+        #expect(dns["Options"] as? String == "ndots:5 timeout:2")
+    }
+
+    @Test
+    func validatesDNSFromActiveSystemConfigurationState() throws {
+        let requested = MacOSGuestDNSConfiguration(
+            nameservers: ["10.96.0.10"],
+            domain: nil,
+            searchDomains: ["default.svc.cluster.local", "svc.cluster.local", "cluster.local"],
+            options: ["ndots:5"]
+        )
+        let properties: NSDictionary = [
+            "ServerAddresses": ["10.96.0.10"],
+            "SearchDomains": ["default.svc.cluster.local", "svc.cluster.local", "cluster.local"],
+            "Options": "ndots:5",
+        ]
+
+        let effective = try GuestSystemNetworkConfigurator.effectiveDNSConfiguration(
+            serviceID: "service-1",
+            interfaceName: "en0",
+            requested: requested,
+            properties: properties
+        )
+
+        #expect(effective.serviceID == "service-1")
+        #expect(effective.interfaceName == "en0")
+        #expect(effective.nameservers == ["10.96.0.10"])
+        #expect(effective.options == ["ndots:5"])
+    }
+
+    @Test
+    func rejectsDNSThatIsNotActiveInSystemConfiguration() throws {
+        let requested = MacOSGuestDNSConfiguration(
+            nameservers: ["10.96.0.10"],
+            domain: nil,
+            searchDomains: ["cluster.local"],
+            options: ["ndots:5"]
+        )
+        let properties: NSDictionary = [
+            "ServerAddresses": ["192.168.64.1"],
+            "SearchDomains": ["cluster.local"],
+            "Options": "ndots:5",
+        ]
+
+        #expect(throws: (any Error).self) {
+            try GuestSystemNetworkConfigurator.effectiveDNSConfiguration(
+                serviceID: "service-1",
+                interfaceName: "en0",
+                requested: requested,
+                properties: properties
+            )
+        }
     }
 
     @Test
@@ -153,24 +234,29 @@ struct GuestNetworkConfiguratorTests {
             ],
             dns: nil
         )
-        let configurator = GuestNetworkConfigurator { executable, arguments in
-            switch (executable, arguments) {
-            case ("/sbin/ifconfig", ["-a"]):
-                return .init(
-                    stdout: "en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1500\n\tether 02:42:ac:11:00:02\n",
-                    stderr: "",
-                    exitCode: 0
-                )
-            case ("/sbin/ifconfig", ["en0"]):
-                return .init(
-                    stdout: "en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1500\n",
-                    stderr: "",
-                    exitCode: 0
-                )
-            default:
-                return .init(stdout: "", stderr: "", exitCode: 0)
+        let configurator = GuestNetworkConfigurator(
+            runCommand: { executable, arguments in
+                switch (executable, arguments) {
+                case ("/sbin/ifconfig", ["-a"]):
+                    return .init(
+                        stdout: "en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1500\n\tether 02:42:ac:11:00:02\n",
+                        stderr: "",
+                        exitCode: 0
+                    )
+                case ("/sbin/ifconfig", ["en0"]):
+                    return .init(
+                        stdout: "en0: flags=8863<UP,BROADCAST,RUNNING> mtu 1500\n",
+                        stderr: "",
+                        exitCode: 0
+                    )
+                default:
+                    return .init(stdout: "", stderr: "", exitCode: 0)
+                }
+            },
+            applySystemConfiguration: { interfaces, _, dns in
+                Self.makeSystemConfigurationResult(interfaces: interfaces, dns: dns)
             }
-        }
+        )
 
         #expect(throws: (any Error).self) {
             try configurator.apply(request)
@@ -179,6 +265,58 @@ struct GuestNetworkConfiguratorTests {
 }
 
 extension GuestNetworkConfiguratorTests {
+    private static func makeSystemConfigurationResult(
+        interfaces: [GuestSystemNetworkConfigurator.InterfaceConfiguration],
+        dns: MacOSGuestDNSConfiguration?
+    ) -> GuestSystemNetworkConfigurator.Result {
+        let applied = interfaces.map {
+            GuestSystemNetworkConfigurator.AppliedInterface(
+                networkID: $0.networkID,
+                interfaceName: $0.interfaceName,
+                macAddress: $0.macAddress,
+                ipv4Address: "\($0.ipv4Address)/\($0.ipv4PrefixLength)"
+            )
+        }
+        let effectiveDNS = dns.map {
+            MacOSGuestEffectiveDNSConfiguration(
+                serviceID: "service-\(interfaces[0].interfaceName)",
+                interfaceName: interfaces[0].interfaceName,
+                nameservers: $0.nameservers,
+                domain: $0.domain,
+                searchDomains: $0.searchDomains,
+                options: $0.options
+            )
+        }
+        return .init(interfaces: applied, effectiveDNS: effectiveDNS)
+    }
+
+    private final class SystemConfigurationRecorder: @unchecked Sendable {
+        struct Invocation: Sendable {
+            let interfaces: [GuestSystemNetworkConfigurator.InterfaceConfiguration]
+            let primaryIndex: Int
+            let dns: MacOSGuestDNSConfiguration?
+        }
+
+        private let lock = NSLock()
+        private var stored: Invocation?
+
+        func record(
+            interfaces: [GuestSystemNetworkConfigurator.InterfaceConfiguration],
+            primaryIndex: Int,
+            dns: MacOSGuestDNSConfiguration?
+        ) {
+            lock.lock()
+            defer { lock.unlock() }
+            stored = .init(interfaces: interfaces, primaryIndex: primaryIndex, dns: dns)
+        }
+
+        func invocation() -> Invocation? {
+            lock.lock()
+            defer { lock.unlock() }
+            return stored
+        }
+    }
+
     private final class CommandRecorder: @unchecked Sendable {
         struct Command: Equatable {
             let executable: String

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceNetworkTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceNetworkTests.swift
@@ -50,7 +50,7 @@ struct MacOSSandboxServiceNetworkTests {
         #expect(attachment.dns?.nameservers == ["9.9.9.9"])
         #expect(attachment.dns?.domain == "example.internal")
         #expect(attachment.dns?.searchDomains == ["svc.example.internal"])
-        #expect(attachment.dns?.options.isEmpty == true)
+        #expect(attachment.dns?.options == ["ndots:5"])
 
         let maybeLease = try MacOSGuestNetworkLeaseStore.load(from: root)
         let lease = try #require(maybeLease)
@@ -90,7 +90,7 @@ struct MacOSSandboxServiceNetworkTests {
                 nameservers: ["9.9.9.9"],
                 domain: "example.internal",
                 searchDomains: ["svc.example.internal"],
-                options: []
+                options: ["ndots:5"]
             )
         )
         let recorder = RecordingSandboxNetworkControl(
@@ -213,7 +213,7 @@ struct MacOSSandboxServiceNetworkTests {
         #expect(attachment.hostname == "sandbox-host")
         #expect(attachment.ipv4Address.address.description == "192.168.64.7")
         #expect(attachment.dns?.nameservers == ["9.9.9.9"])
-        #expect(attachment.dns?.options.isEmpty == true)
+        #expect(attachment.dns?.options == ["ndots:5"])
         #expect(await recorder.lookupCalls() == [RecordingSandboxNetworkControl.Key(network: "default", hostname: "sandbox-host")])
     }
 

--- a/Tests/RuntimeMacOSSidecarSharedTests/SidecarGuestNetworkingProtocolTests.swift
+++ b/Tests/RuntimeMacOSSidecarSharedTests/SidecarGuestNetworkingProtocolTests.swift
@@ -81,4 +81,37 @@ struct SidecarGuestNetworkingProtocolTests {
 
         #expect(decoded.effectiveMTU == nil)
     }
+
+    @Test
+    func networkResultRoundTripPreservesEffectiveDNS() throws {
+        let result = MacOSGuestNetworkConfigurationResult(
+            interfaces: [],
+            dnsApplied: true,
+            effectiveDNS: .init(
+                serviceID: "service-1",
+                interfaceName: "en0",
+                nameservers: ["10.96.0.10"],
+                domain: nil,
+                searchDomains: ["default.svc.cluster.local", "svc.cluster.local", "cluster.local"],
+                options: ["ndots:5"]
+            )
+        )
+
+        let decoded = try JSONDecoder().decode(
+            MacOSGuestNetworkConfigurationResult.self,
+            from: JSONEncoder().encode(result)
+        )
+
+        #expect(decoded == result)
+    }
+
+    @Test
+    func decodesLegacyNetworkResultWithoutEffectiveDNS() throws {
+        let data = Data(#"{"interfaces":[],"dnsApplied":true,"warnings":[]}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(MacOSGuestNetworkConfigurationResult.self, from: data)
+
+        #expect(decoded.dnsApplied)
+        #expect(decoded.effectiveDNS == nil)
+    }
 }

--- a/Tests/RuntimeMacOSSidecarTests/MacOSGuestNetworkBootstrapTests.swift
+++ b/Tests/RuntimeMacOSSidecarTests/MacOSGuestNetworkBootstrapTests.swift
@@ -64,7 +64,7 @@ struct MacOSGuestNetworkBootstrapTests {
         #expect(request.dns?.nameservers == ["9.9.9.9"])
         #expect(request.dns?.domain == "cluster.local")
         #expect(request.dns?.searchDomains == ["svc.cluster.local"])
-        #expect(request.dns?.options == [])
+        #expect(request.dns?.options == ["ndots:5"])
     }
 
     @Test
@@ -73,6 +73,43 @@ struct MacOSGuestNetworkBootstrapTests {
         let result = makeGuestNetworkResult(effectiveMTU: 1_450)
 
         try MacOSGuestNetworkBootstrap.validateResult(result, for: request)
+    }
+
+    @Test
+    func acceptsGuestResultWithMatchingEffectiveDNS() throws {
+        let request = makeGuestNetworkRequestWithDNS()
+        let result = makeGuestNetworkResultWithDNS(
+            nameservers: ["10.96.0.10"],
+            options: ["ndots:5"]
+        )
+
+        try MacOSGuestNetworkBootstrap.validateResult(result, for: request)
+    }
+
+    @Test
+    func rejectsLegacyDNSResultWithoutEffectiveResolverDetails() throws {
+        let request = makeGuestNetworkRequestWithDNS()
+        let result = MacOSGuestNetworkConfigurationResult(
+            interfaces: makeGuestNetworkResult(effectiveMTU: 1_450).interfaces,
+            dnsApplied: true
+        )
+
+        #expect(throws: (any Error).self) {
+            try MacOSGuestNetworkBootstrap.validateResult(result, for: request)
+        }
+    }
+
+    @Test
+    func rejectsGuestResultWithDifferentEffectiveDNSOptions() throws {
+        let request = makeGuestNetworkRequestWithDNS()
+        let result = makeGuestNetworkResultWithDNS(
+            nameservers: ["10.96.0.10"],
+            options: []
+        )
+
+        #expect(throws: (any Error).self) {
+            try MacOSGuestNetworkBootstrap.validateResult(result, for: request)
+        }
     }
 
     @Test
@@ -215,6 +252,24 @@ private func makeGuestNetworkRequest(mtu: UInt32?) -> MacOSGuestNetworkConfigura
     )
 }
 
+private func makeGuestNetworkRequestWithDNS() -> MacOSGuestNetworkConfigurationRequest {
+    MacOSGuestNetworkConfigurationRequest(
+        interfaces: [
+            makeGuestNetworkInterface(
+                networkID: "default",
+                macAddress: "02:42:ac:11:00:02",
+                mtu: 1_450
+            )
+        ],
+        dns: .init(
+            nameservers: ["10.96.0.10"],
+            domain: nil,
+            searchDomains: ["default.svc.cluster.local", "svc.cluster.local", "cluster.local"],
+            options: ["ndots:5"]
+        )
+    )
+}
+
 private func makeGuestNetworkInterface(
     networkID: String,
     macAddress: String,
@@ -241,6 +296,24 @@ private func makeGuestNetworkResult(effectiveMTU: UInt32?) -> MacOSGuestNetworkC
             )
         ],
         dnsApplied: false
+    )
+}
+
+private func makeGuestNetworkResultWithDNS(
+    nameservers: [String],
+    options: [String]
+) -> MacOSGuestNetworkConfigurationResult {
+    .init(
+        interfaces: makeGuestNetworkResult(effectiveMTU: 1_450).interfaces,
+        dnsApplied: true,
+        effectiveDNS: .init(
+            serviceID: "service-1",
+            interfaceName: "en0",
+            nameservers: nameservers,
+            domain: nil,
+            searchDomains: ["default.svc.cluster.local", "svc.cluster.local", "cluster.local"],
+            options: options
+        )
     )
 }
 


### PR DESCRIPTION
## Summary

- configure macOS guest IPv4 and DNS in one SystemConfiguration transaction
- verify active resolver state through SCDynamicStore and reject mismatches
- preserve CRI and CLI DNS options end to end

## Root cause

The guest agent configured addresses and routes through transient shell commands while DNS used networksetup independently. That split state across interfaces and services, provided no atomic rollback, and reported success without confirming the resolver state consumed by macOS.

## Impact

macOS workloads now receive kubelet DNS settings through the native SystemConfiguration database. Startup succeeds only after the active IPv4 and DNS state matches the requested configuration.

## Validation

- make fmt
- make check
- swift build --target container-macos-guest-agent -Xswiftc -warnings-as-errors
- swift build --target MacOSGuestAgentTests -Xswiftc -warnings-as-errors
- swift build --target RuntimeMacOSSidecarSharedTests -Xswiftc -warnings-as-errors

The local Xcode 16.2 SDK cannot complete the sidecar build because Security types used by grpc-swift-nio-transport lack Sendable annotations. GitHub macOS CI provides the authoritative full build.