### PR TITLE
ci: skip integration coverage without virtualization

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -249,7 +249,11 @@ jobs:
         run: |
           mkdir -p pr-coverage
           jq -r '.data[0].totals.lines.percent | . * 100 | round | . / 100' coverage-reports/unit/coverage-summary.json > pr-coverage/unit-line-coverage.txt
-          jq -r '.data[0].totals.lines.percent | . * 100 | round | . / 100' coverage-reports/integration/coverage-summary.json > pr-coverage/integration-line-coverage.txt
+          if [ -f coverage-reports/integration/coverage-summary.json ]; then
+            jq -r '.data[0].totals.lines.percent | . * 100 | round | . / 100' coverage-reports/integration/coverage-summary.json > pr-coverage/integration-line-coverage.txt
+          else
+            echo skipped > pr-coverage/integration-line-coverage.txt
+          fi
           jq -r '.data[0].totals.lines.percent | . * 100 | round | . / 100' coverage-reports/combined/coverage-summary.json > pr-coverage/combined-line-coverage.txt
           echo "${PR_NUMBER}" > pr-coverage/pr-number.txt
           echo "Coverage data:"

--- a/.github/workflows/pr-coverage-comment.yml
+++ b/.github/workflows/pr-coverage-comment.yml
@@ -55,7 +55,14 @@ jobs:
           grep -qxE '[0-9]+(\.[0-9]+)?' <<< "$UNIT" || { echo "Invalid unit coverage: ${UNIT}"; exit 1; }
 
           INTEGRATION=$(cat pr-coverage-data/integration-line-coverage.txt)
-          grep -qxE '[0-9]+(\.[0-9]+)?' <<< "$INTEGRATION" || { echo "Invalid integration coverage: ${INTEGRATION}"; exit 1; }
+          if [ "$INTEGRATION" = "skipped" ]; then
+            INTEGRATION_DISPLAY="Skipped"
+            COMBINED_LABEL="Combined (unit only)"
+          else
+            grep -qxE '[0-9]+(\.[0-9]+)?' <<< "$INTEGRATION" || { echo "Invalid integration coverage: ${INTEGRATION}"; exit 1; }
+            INTEGRATION_DISPLAY="${INTEGRATION}%"
+            COMBINED_LABEL="Combined"
+          fi
 
           COMBINED=$(cat pr-coverage-data/combined-line-coverage.txt)
           grep -qxE '[0-9]+(\.[0-9]+)?' <<< "$COMBINED" || { echo "Invalid combined coverage: ${COMBINED}"; exit 1; }
@@ -68,8 +75,8 @@ jobs:
           | Tier | Line Coverage |
           |------|--------------|
           | Unit | ${UNIT}% |
-          | Integration | ${INTEGRATION}% |
-          | Combined | ${COMBINED}% |
+          | Integration | ${INTEGRATION_DISPLAY} |
+          | ${COMBINED_LABEL} | ${COMBINED}% |
           EOF
           )
 

--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,7 @@ else
 endif
 
 .PHONY: coverage-integration
+ifeq ($(SKIP_VIRTUALIZATION_TESTS),)
 coverage-integration: INTEGRATION_SWIFT_EXTRA = --skip-build --enable-code-coverage
 coverage-integration: INTEGRATION_POST_TEST = cp $(COV_DATA_DIR)/*.profraw $(COVERAGE_OUTPUT_DIR)/integration/ || true ;
 # Continuous mode (%c) mmaps the profraw and syncs counters live. The XPC helper
@@ -392,6 +393,11 @@ coverage-integration: coverage-all
 	@echo Merging integration coverage profdata...
 	@xcrun llvm-profdata merge -sparse $(COVERAGE_OUTPUT_DIR)/integration/*.profraw -o $(COVERAGE_OUTPUT_DIR)/integration/default.profdata
 	$(call GENERATE_COV_REPORTS,$(COVERAGE_OUTPUT_DIR)/integration/default.profdata,integration,$(COV_OBJECT_FLAGS))
+else
+coverage-integration:
+	@rm -rf $(COVERAGE_OUTPUT_DIR)/integration
+	@echo Skipping integration coverage because CONTAINER_SKIP_VIRTUALIZATION_TESTS=$(CONTAINER_SKIP_VIRTUALIZATION_TESTS)
+endif
 
 empty :=
 space := $(empty) $(empty)
@@ -401,8 +407,16 @@ space := $(empty) $(empty)
 coverage coverage-all coverage-unit coverage-integration: COVERAGE_FLAG = --enable-code-coverage -Xswiftc -DCONTAINER_COVERAGE
 
 .PHONY: coverage
-# Merge the per-tier profdata from coverage-unit and coverage-integration into a
-# combined report. Each prerequisite target produces its own tier report first.
+# Merge the available tier profdata into a combined report. Hosted runners that
+# cannot run nested virtualization use the unit profile as the combined profile
+# and report the integration tier as skipped.
+ifneq ($(SKIP_VIRTUALIZATION_TESTS),)
+coverage: coverage-unit coverage-integration
+	@echo Generating unit-only combined coverage because integration coverage is skipped...
+	@mkdir -p $(COVERAGE_OUTPUT_DIR)/combined
+	@cp $(COVERAGE_OUTPUT_DIR)/unit/default.profdata $(COVERAGE_OUTPUT_DIR)/combined/default.profdata
+	$(call GENERATE_COV_REPORTS,$(COVERAGE_OUTPUT_DIR)/combined/default.profdata,combined)
+else
 coverage: coverage-unit coverage-integration
 	@echo Merging combined coverage profdata...
 	@mkdir -p $(COVERAGE_OUTPUT_DIR)/combined
@@ -411,6 +425,7 @@ coverage: coverage-unit coverage-integration
 		$(COVERAGE_OUTPUT_DIR)/integration/default.profdata \
 		-o $(COVERAGE_OUTPUT_DIR)/combined/default.profdata
 	$(call GENERATE_COV_REPORTS,$(COVERAGE_OUTPUT_DIR)/combined/default.profdata,combined,$(COV_OBJECT_FLAGS))
+endif
 
 .PHONY: coverage-unit
 coverage-unit: build-tests


### PR DESCRIPTION
## Summary

- make integration coverage honor `CONTAINER_SKIP_VIRTUALIZATION_TESTS`
- generate a unit-only combined report when integration coverage is unavailable
- report the integration tier as skipped instead of publishing a misleading percentage

## Root cause

The ordinary integration target already skipped VM tests on hosted runners, but the coverage integration target invoked the VM test recipe directly. PR coverage therefore attempted to start virtual machines on GitHub macOS runners that do not provide nested virtualization.

## Impact

Hosted PR runners complete unit coverage without attempting VM integration tests. Virtualization-capable environments keep the existing unit, integration, and combined coverage behavior.

## Validation

- make fmt
- make check
- parsed both modified workflow YAML files
- verified skip-mode dry runs contain no system start or integration test command
- verified normal-mode dry runs retain integration coverage
- verified skip mode removes stale integration reports