### PR TITLE
Limit macOS nodes to two pods

### DIFF
--- a/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
+++ b/Sources/ContainerMacOSKubeadm/MacOSKubeadmRendering.swift
@@ -109,6 +109,7 @@ public enum MacOSKubeadmRenderer {
         enableServer: true
         localStorageCapacityIsolation: true
         makeIPTablesUtilChains: false
+        maxPods: 2
         clusterDNS:
           - "\(clusterDNS)"
         clusterDomain: "\(clusterDomain)"

--- a/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
+++ b/Tests/ContainerMacOSKubeadmTests/MacOSKubeadmPlanTests.swift
@@ -67,6 +67,7 @@ struct MacOSKubeadmPlanTests {
                     && contents.contains(#""10.96.0.53""#)
                     && contents.contains("enforceNodeAllocatable: []")
                     && contents.contains("localStorageCapacityIsolation: true")
+                    && contents.contains("maxPods: 2")
                     && contents.contains(#"memory.available: "0%""#)
                     && !contents.contains("podLogsDir:")
                     && !contents.contains("failCgroupV1:")

--- a/packaging/macos-node/config/kubelet-config.yaml
+++ b/packaging/macos-node/config/kubelet-config.yaml
@@ -19,6 +19,7 @@ eventRecordQPS: 5
 enableServer: true
 localStorageCapacityIsolation: true
 makeIPTablesUtilChains: false
+maxPods: 2
 clusterDNS:
   - "10.96.0.10"
 clusterDomain: "cluster.local"


### PR DESCRIPTION
## Summary

- Set `maxPods: 2` in the kubelet configuration generated by the macOS kubeadm flow.
- Keep the packaged macOS node kubelet configuration aligned with the generated configuration.
- Verify the generated join plan contains the pod limit.

## Why

macOS workers should advertise and enforce a two-pod capacity instead of inheriting Kubernetes' generic kubelet default. Keeping the value in the macOS-specific configuration avoids changing non-macOS nodes.

## Impact

Newly generated or installed macOS kubelet configurations limit each node to two pods. Existing nodes need the updated configuration deployed and kubelet restarted before the new capacity is advertised.

## Validation

- `git diff --check`
- Parsed `packaging/macos-node/config/kubelet-config.yaml` and asserted `maxPods == 2`
- Compiled the macOS kubeadm renderer with Swift 6.2.0 and executed an assertion against the rendered kubelet configuration
- Formatted the changed Swift files with Swift 6.2.0

Repository-wide `make fmt` stops on existing trailing-comma syntax in unrelated files. `swift test --filter MacOSKubeadmPlanTests` is currently blocked while compiling the resolved `swift-configuration` dependency because `Data.bytes` is unavailable in the local Swift 6.2.0 and 6.3.2 toolchains.