### PR TITLE
fix: reclaim orphaned macOS runtime VMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ CONTAINER_SKIP_VIRTUALIZATION_TESTS ?= 0
 SWIFT_CONFIGURATION := $(if $(filter-out false,$(WARNINGS_AS_ERRORS)),-Xswiftc -warnings-as-errors) -Xswiftc -enable-testing
 FORK_ISOLATED_UNIT_TEST_SUITE := GuestAgentProcessStartupTests
 IO_ISOLATED_UNIT_TEST_SUITE := CRIShimRuntimeServerTests
+WRITER_ISOLATED_UNIT_TEST_SUITE := FileHandleByteWriterTests
 SKIP_VIRTUALIZATION_TESTS := $(filter 1 true TRUE yes YES,$(CONTAINER_SKIP_VIRTUALIZATION_TESTS))
 # Code-coverage instrumentation, layered onto the shared build stages. Empty for
 # ordinary builds; the coverage-* targets opt in via a target-specific value so
@@ -233,9 +234,10 @@ dsym:
 
 .PHONY: test
 test: build-tests
-	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE)
+	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE) --skip $(WRITER_ISOLATED_UNIT_TEST_SUITE)
 	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(FORK_ISOLATED_UNIT_TEST_SUITE)
 	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(IO_ISOLATED_UNIT_TEST_SUITE)
+	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(WRITER_ISOLATED_UNIT_TEST_SUITE)
 
 .PHONY: install-kernel
 install-kernel:
@@ -437,9 +439,10 @@ coverage-unit: build-tests
 	@echo Running unit test coverage...
 	@mkdir -p $(UNIT_COVERAGE_RAW_DIR)
 	@rm -f $(UNIT_COVERAGE_RAW_DIR)/*.profraw
-	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-main-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE)
+	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-main-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE) --skip $(WRITER_ISOLATED_UNIT_TEST_SUITE)
 	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-guest-process-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(FORK_ISOLATED_UNIT_TEST_SUITE)
 	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-cri-streaming-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(IO_ISOLATED_UNIT_TEST_SUITE)
+	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-file-handle-writer-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(WRITER_ISOLATED_UNIT_TEST_SUITE)
 	@echo Merging unit coverage profdata...
 	@xcrun llvm-profdata merge -sparse $(UNIT_COVERAGE_RAW_DIR)/*.profraw -o $(COVERAGE_OUTPUT_DIR)/unit/default.profdata
 	$(call GENERATE_COV_REPORTS,$(COVERAGE_OUTPUT_DIR)/unit/default.profdata,unit)

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SWIFT_CONFIGURATION := $(if $(filter-out false,$(WARNINGS_AS_ERRORS)),-Xswiftc -
 FORK_ISOLATED_UNIT_TEST_SUITE := GuestAgentProcessStartupTests
 IO_ISOLATED_UNIT_TEST_SUITE := CRIShimRuntimeServerTests
 WRITER_ISOLATED_UNIT_TEST_SUITE := FileHandleByteWriterTests
+SIDECAR_CLIENT_ISOLATED_UNIT_TEST_TARGET := RuntimeMacOSSidecarClientTests
 SKIP_VIRTUALIZATION_TESTS := $(filter 1 true TRUE yes YES,$(CONTAINER_SKIP_VIRTUALIZATION_TESTS))
 # Code-coverage instrumentation, layered onto the shared build stages. Empty for
 # ordinary builds; the coverage-* targets opt in via a target-specific value so
@@ -234,10 +235,11 @@ dsym:
 
 .PHONY: test
 test: build-tests
-	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE) --skip $(WRITER_ISOLATED_UNIT_TEST_SUITE)
+	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE) --skip $(WRITER_ISOLATED_UNIT_TEST_SUITE) --skip $(SIDECAR_CLIENT_ISOLATED_UNIT_TEST_TARGET)
 	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(FORK_ISOLATED_UNIT_TEST_SUITE)
 	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(IO_ISOLATED_UNIT_TEST_SUITE)
 	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(WRITER_ISOLATED_UNIT_TEST_SUITE)
+	@$(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(SIDECAR_CLIENT_ISOLATED_UNIT_TEST_TARGET)
 
 .PHONY: install-kernel
 install-kernel:
@@ -439,10 +441,11 @@ coverage-unit: build-tests
 	@echo Running unit test coverage...
 	@mkdir -p $(UNIT_COVERAGE_RAW_DIR)
 	@rm -f $(UNIT_COVERAGE_RAW_DIR)/*.profraw
-	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-main-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE) --skip $(WRITER_ISOLATED_UNIT_TEST_SUITE)
+	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-main-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --skip TestCLI --skip IntegrationTests --skip $(FORK_ISOLATED_UNIT_TEST_SUITE) --skip $(IO_ISOLATED_UNIT_TEST_SUITE) --skip $(WRITER_ISOLATED_UNIT_TEST_SUITE) --skip $(SIDECAR_CLIENT_ISOLATED_UNIT_TEST_TARGET)
 	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-guest-process-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(FORK_ISOLATED_UNIT_TEST_SUITE)
 	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-cri-streaming-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(IO_ISOLATED_UNIT_TEST_SUITE)
 	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-file-handle-writer-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(WRITER_ISOLATED_UNIT_TEST_SUITE)
+	@LLVM_PROFILE_FILE="$(UNIT_COVERAGE_RAW_DIR)/unit-sidecar-client-%p-%m.profraw" $(SWIFT) test --skip-build -c $(BUILD_CONFIGURATION) $(SWIFT_CONFIGURATION) --filter $(SIDECAR_CLIENT_ISOLATED_UNIT_TEST_TARGET)
 	@echo Merging unit coverage profdata...
 	@xcrun llvm-profdata merge -sparse $(UNIT_COVERAGE_RAW_DIR)/*.profraw -o $(COVERAGE_OUTPUT_DIR)/unit/default.profdata
 	$(call GENERATE_COV_REPORTS,$(COVERAGE_OUTPUT_DIR)/unit/default.profdata,unit)

--- a/Package.swift
+++ b/Package.swift
@@ -265,6 +265,7 @@ let package = Package(
                 "ContainerCRIShimMacOS",
                 "ContainerKit",
                 "ContainerK8sNetworkPolicyMacOS",
+                "ContainerResource",
                 "RuntimeMacOSSidecarShared",
             ]
         ),
@@ -490,6 +491,7 @@ let package = Package(
                 "ContainerRuntimeClient",
                 "ContainerVersion",
                 "ContainerXPC",
+                "RuntimeMacOSSidecarShared",
                 "TerminalProgress",
             ],
             path: "Sources/Services/ContainerAPIService/Server"
@@ -499,6 +501,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Containerization", package: "containerization"),
                 "ContainerAPIService",
+                "ContainerPlugin",
                 "ContainerResource",
                 "ContainerRuntimeLinuxClient",
                 "ContainerRuntimeClient",

--- a/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimGRPCServices.swift
@@ -374,8 +374,8 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
             response.podSandboxID = sandboxID
             return response
         }
-        var sandboxCreated = false
         var metadataPersisted = false
+        var runtimeCreationAttempted = false
         var networkAttachAttempted = false
 
         do {
@@ -420,15 +420,18 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
                 )
                 leaseAcquisition = acquisition
             }
-            try await runtimeManager.createSandbox(configuration: sandboxConfiguration)
-            sandboxCreated = true
             try metadataStore.upsertSandbox(metadata)
             metadataPersisted = true
+            runtimeCreationAttempted = true
+            try await runtimeManager.createSandbox(configuration: sandboxConfiguration)
             if handler.usesPodNetworking {
                 try vmnetRecoveryController.requireAdmission(
                     gate: .beforeNetworkAttach,
                     attemptID: admissionAttemptID
                 )
+                metadata.networkAttachments = [handler.network]
+                metadata.updatedAt = Date()
+                try metadataStore.upsertSandbox(metadata)
                 networkAttachAttempted = true
                 let network: CRIShimCNIResult
                 if let identityManager = cniManager as? any CRIShimCNIIdentityManaging {
@@ -452,33 +455,41 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
             try metadataStore.upsertSandbox(metadata)
         } catch {
             let admissionError = error
-            if networkAttachAttempted {
-                let runtimeSandboxID = machineState.machineState?.persistenceID ?? sandboxID
-                if let identityManager = cniManager as? any CRIShimCNIIdentityManaging {
-                    try? await identityManager.delete(
-                        identity: .init(
-                            runtimeSandboxID: runtimeSandboxID,
-                            criSandboxID: sandboxID,
-                            restoreRequestID: request.config.annotations[CRIShimMachineStateAnnotation.restoreRequestID],
-                            podUID: request.config.metadata.uid
-                        ),
-                        networkName: handler.network,
-                        config: config
-                    )
-                } else {
-                    try? await cniManager.delete(
-                        sandboxID: runtimeSandboxID,
-                        networkName: handler.network,
-                        config: config
-                    )
-                }
-            }
             if let leaseAcquisition, leaseAcquisition.created, let policy = config.machineState {
+                var networkRollbackError: (any Error)?
+                if networkAttachAttempted {
+                    do {
+                        let runtimeSandboxID = machineState.machineState?.persistenceID ?? sandboxID
+                        if let identityManager = cniManager as? any CRIShimCNIIdentityManaging {
+                            try await identityManager.delete(
+                                identity: .init(
+                                    runtimeSandboxID: runtimeSandboxID,
+                                    criSandboxID: sandboxID,
+                                    restoreRequestID: request.config.annotations[CRIShimMachineStateAnnotation.restoreRequestID],
+                                    podUID: request.config.metadata.uid
+                                ),
+                                networkName: handler.network,
+                                config: config
+                            )
+                        } else {
+                            try await cniManager.delete(
+                                sandboxID: runtimeSandboxID,
+                                networkName: handler.network,
+                                config: config
+                            )
+                        }
+                    } catch {
+                        networkRollbackError = error
+                    }
+                }
                 switch leaseAcquisition.lease.admissionState {
                 case .runtimeCreationStarted, nil:
                     let cleanupConfirmation = try await CRIShimMachineStateRuntimeCleaner(
                         runtimeManager: runtimeManager
                     ).cleanup(lease: leaseAcquisition.lease, policy: policy)
+                    if let networkRollbackError {
+                        throw networkRollbackError
+                    }
                     if metadataPersisted {
                         try metadataStore.deleteSandbox(id: sandboxID)
                     }
@@ -488,6 +499,9 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
                     )
                     withExtendedLifetime(cleanupConfirmation) {}
                 case .runtimeDeletionConfirmed:
+                    if let networkRollbackError {
+                        throw networkRollbackError
+                    }
                     if metadataPersisted {
                         try metadataStore.deleteSandbox(id: sandboxID)
                     }
@@ -496,21 +510,58 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
                         expected: leaseAcquisition.lease
                     )
                 case .reserved:
+                    if let networkRollbackError {
+                        throw networkRollbackError
+                    }
                     try CRIShimMachineStateLeaseStore.release(
                         policy: policy,
                         expected: leaseAcquisition.lease
                     )
                 }
             } else {
-                if sandboxCreated {
-                    let runtimeSandboxID =
-                        (try? metadataStore.sandbox(id: sandboxID))?.runtimeSandboxID
-                        ?? machineState.machineState?.persistenceID
-                        ?? sandboxID
-                    try? await runtimeManager.removeSandbox(id: runtimeSandboxID, force: true)
+                var rollbackError: (any Error)?
+                if runtimeCreationAttempted {
+                    do {
+                        try await runtimeManager.removeSandbox(id: sandboxID, force: true)
+                    } catch {
+                        do {
+                            try throwUnlessNotFound(error)
+                        } catch {
+                            rollbackError = error
+                        }
+                    }
+                }
+                if networkAttachAttempted {
+                    do {
+                        if let identityManager = cniManager as? any CRIShimCNIIdentityManaging {
+                            try await identityManager.delete(
+                                identity: .init(
+                                    runtimeSandboxID: sandboxID,
+                                    criSandboxID: sandboxID,
+                                    restoreRequestID: request.config.annotations[CRIShimMachineStateAnnotation.restoreRequestID],
+                                    podUID: request.config.metadata.uid
+                                ),
+                                networkName: handler.network,
+                                config: config
+                            )
+                        } else {
+                            try await cniManager.delete(
+                                sandboxID: sandboxID,
+                                networkName: handler.network,
+                                config: config
+                            )
+                        }
+                    } catch {
+                        if rollbackError == nil {
+                            rollbackError = error
+                        }
+                    }
+                }
+                if let rollbackError {
+                    throw rollbackError
                 }
                 if metadataPersisted {
-                    try? metadataStore.deleteSandbox(id: sandboxID)
+                    try metadataStore.deleteSandbox(id: sandboxID)
                 }
             }
             throw admissionError
@@ -1664,6 +1715,7 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
             var observed = metadata.applying(sandboxSnapshot: snapshot)
             if hasActiveContainers,
                 snapshot.status != .running,
+                snapshot.status != .stopping,
                 snapshot.failureReason != .networkInvalidated
             {
                 observed.state = metadata.state
@@ -1792,7 +1844,11 @@ public final class CRIShimRuntimeServiceProvider: Runtime_V1_RuntimeServiceAsync
 
         let containers = try metadataStore.listContainers()
             .filter { $0.sandboxID == metadata.id }
-        var sandboxStopped = metadata.state == .stopped
+        let usesMachineState =
+            metadata.annotations[CRIShimMachineStateAnnotation.enabled] == "true"
+        // Ordinary macOS cleanup requires independent process and file proof
+        // before metadata can advance to stopped.
+        var sandboxStopped = usesMachineState && metadata.state == .stopped
 
         if !sandboxStopped {
             do {

--- a/Sources/ContainerCRIShimMacOS/CRIShimReconcile.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimReconcile.swift
@@ -721,9 +721,9 @@ private func makeCRIShimSandboxMetadataState(_ status: RuntimeStatus) -> CRIShim
     switch status {
     case .running:
         .running
-    case .stopping, .stopped:
+    case .stopped:
         .stopped
-    case .unknown:
+    case .stopping, .unknown:
         .pending
     }
 }

--- a/Sources/ContainerCRIShimMacOS/CRIShimStatusMapping.swift
+++ b/Sources/ContainerCRIShimMacOS/CRIShimStatusMapping.swift
@@ -570,7 +570,8 @@ extension CRIShimSandboxMetadata {
         case .running:
             observedState = .running
         case .stopping:
-            observedState = .stopped
+            metadata.state = .pending
+            return metadata.applyingNetworkAttachments(from: sandboxSnapshot)
         case .stopped:
             let preservesIncompleteMachineStateAdmission =
                 metadata.state == .pending

--- a/Sources/ContainerPlugin/MacOSRuntimeCleanup.swift
+++ b/Sources/ContainerPlugin/MacOSRuntimeCleanup.swift
@@ -1,0 +1,301 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import Darwin
+import Foundation
+
+/// Reclaims the launchd instances and VM files belonging to one stateless
+/// macOS sandbox. The bundle is the durable retry record and must outlive this
+/// operation.
+public struct MacOSRuntimeCleanup {
+    public static let pendingFilename = "runtime-cleanup-pending"
+
+    struct CommandResult {
+        var status: Int32
+        var output: String
+        var error: String = ""
+    }
+
+    var run: (String, [String]) throws -> CommandResult = Self.runCommand
+    var processExists: (Int32) -> Bool = { kill($0, 0) == 0 || errno != ESRCH }
+    var sleep: () -> Void = { Thread.sleep(forTimeInterval: 0.1) }
+    var attempts = 50
+
+    public init() {}
+
+    public static func markPending(root: URL) throws {
+        try Data().write(to: root.appendingPathComponent(pendingFilename), options: .atomic)
+    }
+
+    public static func isPending(root: URL) -> Bool {
+        FileManager.default.fileExists(atPath: root.appendingPathComponent(pendingFilename).path)
+    }
+
+    public static func clearPending(root: URL) throws {
+        let marker = root.appendingPathComponent(pendingFilename)
+        do {
+            try FileManager.default.removeItem(at: marker)
+        } catch let error as CocoaError where error.code == .fileNoSuchFile {
+            return
+        }
+    }
+
+    /// Run bounded host probes off the runtime/API actor so inventory requests
+    /// for other sandboxes remain responsive while cleanup is pending.
+    public static func stop(
+        id: String,
+        root: URL,
+        parentLabel: String? = nil,
+        sidecarLabel: String
+    ) async throws {
+        try await Task.detached {
+            try Self().stop(
+                id: id,
+                root: root,
+                parentLabel: parentLabel,
+                sidecarLabel: sidecarLabel
+            )
+        }.value
+    }
+
+    public static func confirmStopped(
+        id: String,
+        root: URL,
+        parentLabel: String,
+        sidecarLabel: String
+    ) async throws {
+        try await Task.detached {
+            try Self().confirmStopped(
+                id: id,
+                root: root,
+                parentLabel: parentLabel,
+                sidecarLabel: sidecarLabel
+            )
+        }.value
+    }
+
+    func stop(
+        id: String,
+        root: URL,
+        parentLabel: String? = nil,
+        sidecarLabel: String
+    ) throws {
+        try validate(id: id, root: root)
+        try Self.markPending(root: root)
+        // Stop the parent first so it cannot bootstrap a replacement sidecar.
+        if let parentLabel {
+            try removeService(label: parentLabel)
+        }
+        try removeService(label: sidecarLabel)
+        let deadline = Date().addingTimeInterval(10)
+        for _ in 0..<attempts {
+            guard Date() < deadline else { break }
+            if try !hasOpenVMFiles(root: root) { return }
+            sleep()
+        }
+        throw ContainerizationError(
+            .timeout,
+            message: "VM still holds sandbox files for \(id); retaining cleanup state"
+        )
+    }
+
+    /// Read-only check used before returning NotFound for missing API metadata.
+    func confirmStopped(
+        id: String,
+        root: URL,
+        parentLabel: String,
+        sidecarLabel: String
+    ) throws {
+        try validate(id: id, root: root)
+        guard try serviceHasExited(label: parentLabel),
+            try serviceHasExited(label: sidecarLabel),
+            try !hasOpenVMFiles(root: root)
+        else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "sandbox \(id) still has runtime resources; retaining metadata"
+            )
+        }
+    }
+
+    public func serviceHasExited(label: String) throws -> Bool {
+        guard let pid = try servicePID(label: label) else { return true }
+        return pid == 0 || !processExists(pid)
+    }
+
+    private func validate(id: String, root: URL) throws {
+        guard !id.isEmpty, id != ".", id != "..",
+            id.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber || "-_.".contains($0)) }),
+            root.lastPathComponent == id
+        else {
+            throw ContainerizationError(
+                .invalidArgument,
+                message: "invalid sandbox cleanup identity"
+            )
+        }
+    }
+
+    private func servicePID(label: String) throws -> Int32? {
+        let result = try run("/bin/launchctl", ["print", label])
+        if result.status == 0 {
+            for line in result.output.split(separator: "\n") {
+                let fields = line.split(whereSeparator: { $0.isWhitespace })
+                if fields.count == 3,
+                    fields[0] == "pid",
+                    fields[1] == "=",
+                    let pid = Int32(fields[2]),
+                    pid > 0
+                {
+                    return pid
+                }
+            }
+            if result.output.split(separator: "\n").contains(where: {
+                $0.trimmingCharacters(in: .whitespaces) == "state = not running"
+            }) {
+                return 0
+            }
+            throw ContainerizationError(
+                .internalError,
+                message: "launchd did not report a recognized process state for \(label)"
+            )
+        }
+        if result.status == 113 || result.status == 3,
+            result.error.contains("Could not find service")
+                || result.error.contains("No such process")
+        {
+            return nil
+        }
+        throw ContainerizationError(
+            .internalError,
+            message: "cannot inspect launchd service \(label): \(result.error)"
+        )
+    }
+
+    private func removeService(label: String) throws {
+        guard let pid = try servicePID(label: label) else { return }
+        let result = try run("/bin/launchctl", ["bootout", label])
+        // A failed bootout can race a successful stop by another caller.
+        // Success still requires independent absence and process-exit proof.
+        let deadline = Date().addingTimeInterval(10)
+        for _ in 0..<attempts {
+            guard Date() < deadline else { break }
+            if try servicePID(label: label) == nil,
+                pid == 0 || !processExists(pid)
+            {
+                return
+            }
+            sleep()
+        }
+        throw ContainerizationError(
+            .timeout,
+            message:
+                "launchd service \(label) has not exited (bootout status \(result.status)): \(result.error)"
+        )
+    }
+
+    private func hasOpenVMFiles(root: URL) throws -> Bool {
+        // Enumerate names instead of querying an inode so open, unlinked files
+        // remain visible. Never signal processes found by this read-only scan.
+        let result = try run(
+            "/usr/sbin/lsof",
+            ["-nP", "-w", "-Fn", "-u", String(getuid())]
+        )
+        guard result.status == 0, result.error.isEmpty else {
+            throw ContainerizationError(
+                .internalError,
+                message: "cannot confirm VM file closure: \(result.error)"
+            )
+        }
+        let roots = Set([root.standardizedFileURL.path, Self.canonicalPath(root)])
+        let paths = Set(
+            roots.flatMap {
+                ["\($0)/Disk.img", "\($0)/AuxiliaryStorage"]
+            })
+        return result.output.split(separator: "\n").contains { line in
+            guard line.first == "n" else { return false }
+            let name = String(line.dropFirst())
+            return paths.contains(name)
+                || paths.contains(
+                    name.replacingOccurrences(of: " (deleted)", with: "")
+                )
+        }
+    }
+
+    private static func canonicalPath(_ url: URL) -> String {
+        var ancestor = url.standardizedFileURL
+        var suffix: [String] = []
+        while true {
+            if let resolved = realpath(ancestor.path, nil) {
+                defer { free(resolved) }
+                return ([String(cString: resolved)] + suffix.reversed())
+                    .joined(separator: "/")
+            }
+            guard ancestor.path != "/" else {
+                return url.standardizedFileURL.path
+            }
+            suffix.append(ancestor.lastPathComponent)
+            ancestor.deleteLastPathComponent()
+        }
+    }
+
+    private static func runCommand(
+        _ executable: String,
+        _ arguments: [String]
+    ) throws -> CommandResult {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let outURL = directory.appendingPathComponent("stdout")
+        let errURL = directory.appendingPathComponent("stderr")
+        FileManager.default.createFile(atPath: outURL.path, contents: nil)
+        FileManager.default.createFile(atPath: errURL.path, contents: nil)
+        let out = try FileHandle(forWritingTo: outURL)
+        let err = try FileHandle(forWritingTo: errURL)
+        defer {
+            try? out.close()
+            try? err.close()
+        }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardOutput = out
+        process.standardError = err
+        try process.run()
+        let deadline = Date().addingTimeInterval(5)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            throw ContainerizationError(
+                .timeout,
+                message: "timed out executing \(executable)"
+            )
+        }
+        process.waitUntilExit()
+        return CommandResult(
+            status: process.terminationStatus,
+            output: String(decoding: try Data(contentsOf: outURL), as: UTF8.self),
+            error: String(decoding: try Data(contentsOf: errURL), as: UTF8.self)
+        )
+    }
+}

--- a/Sources/Helpers/RuntimeMacOS/MacOSSandboxService+Sidecar.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSandboxService+Sidecar.swift
@@ -154,12 +154,17 @@ extension MacOSSandboxService {
             machineState: config.macosGuest?.machineState
         )
 
-        // A stable launch label lets a recreated sandbox clean up an orphaned
-        // sidecar only after it has acquired the persistence lease. Refuse to
-        // unlink its socket if launchd cannot terminate it.
         if config.macosGuest?.machineState == nil {
-            try? bootoutLaunchAgent(fullLabel: sidecarFullLaunchLabel(config: config))
+            try await MacOSRuntimeCleanup.stop(
+                id: config.id,
+                root: root,
+                sidecarLabel: sidecarFullLaunchLabel(config: config)
+            )
+            try MacOSRuntimeCleanup.clearPending(root: root)
         } else {
+            // A stable launch label lets a recreated sandbox clean up an
+            // orphaned sidecar only after it has acquired the persistence
+            // lease.
             try bootoutLaunchAgent(fullLabel: sidecarFullLaunchLabel(config: config))
         }
         try removeStaleSidecarSocket(socketURL)
@@ -235,6 +240,47 @@ extension MacOSSandboxService {
 
     func stopAndQuitSidecarIfPresent() async throws {
         let config = configuration
+        if let config, config.macosGuest?.machineState == nil {
+            let handle = sidecarHandle
+            try MacOSRuntimeCleanup.markPending(root: root)
+            writeContainerLog(
+                Data(
+                    ("sidecar shutdown begin [label=\(handle?.launchLabel ?? sidecarLaunchLabel(config: config))]\n").utf8
+                )
+            )
+            handle?.client.setDisconnectHandler(nil)
+            do {
+                try handle?.client.stopVM()
+            } catch {
+                writeContainerLog(
+                    Data(
+                        ("sidecar stopVM failed [label=\(handle?.launchLabel ?? sidecarLaunchLabel(config: config))] error=\(String(describing: error))\n").utf8
+                    )
+                )
+            }
+            do {
+                try handle?.client.quit()
+            } catch {
+                writeContainerLog(
+                    Data(
+                        ("sidecar quit failed [label=\(handle?.launchLabel ?? sidecarLaunchLabel(config: config))] error=\(String(describing: error))\n").utf8
+                    )
+                )
+            }
+            await drainPendingSidecarExitEvents()
+            handle?.client.setEventHandler(nil)
+            await finishAndDrainSidecarEventPump()
+            try await MacOSRuntimeCleanup.stop(
+                id: config.id,
+                root: root,
+                sidecarLabel: sidecarFullLaunchLabel(config: config)
+            )
+            sidecarHandle = nil
+            handle?.client.closeControlConnection()
+            releaseMachineStateLeaseIfPresent()
+            return
+        }
+
         let requiresVerifiedCleanup = config?.macosGuest?.machineState != nil || machineStateLeaseFD >= 0
         guard let handle = sidecarHandle else {
             guard let config else {

--- a/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
+++ b/Sources/Helpers/RuntimeMacOS/MacOSSandboxService.swift
@@ -3485,7 +3485,7 @@ extension MacOSSandboxService {
         try Task.checkCancellation()
 
         let waiterID = UUID()
-        return try await withTaskCancellationHandler {
+        let status: ExitStatus = try await withTaskCancellationHandler {
             try Task.checkCancellation()
             return await withCheckedContinuation { continuation in
                 if let status = sessions[sessionID]?.exitStatus {
@@ -3505,6 +3505,8 @@ extension MacOSSandboxService {
         } onCancel: {
             Task { await self.cancelWaiter(id: sessionID, waiterID: waiterID, reason: "wait_cancelled") }
         }
+        try Task.checkCancellation()
+        return status
     }
 
     private func addWaiter(id: String, waiterID: UUID, continuation: CheckedContinuation<ExitStatus, Never>) {
@@ -4437,6 +4439,16 @@ extension MacOSSandboxService {
             }
         }
 
+        guard configuration?.macosGuest?.machineState != nil else {
+            // A control transport failure does not prove that the sidecar,
+            // guest workloads, or VM have exited. Explicit stop and API-level
+            // recovery retain enough identity to perform verified cleanup.
+            writeContainerLog(
+                Data("sidecar control recovery pending; preserving sidecar and workload sessions\n".utf8)
+            )
+            return
+        }
+
         sidecarHandle?.client.setEventHandler(nil)
         sidecarHandle?.client.setDisconnectHandler(nil)
         sidecarHandle = nil
@@ -4539,6 +4551,7 @@ extension MacOSSandboxService {
                     "failed to stop sandbox after vmnet helper disconnect",
                     metadata: ["error": "\(error)"]
                 )
+                return
             }
             sandboxState = .stopped(255)
         }

--- a/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
+++ b/Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift
@@ -27,8 +27,10 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
+import Darwin
 import Foundation
 import Logging
+import RuntimeMacOSSidecarShared
 import SystemPackage
 
 private struct SendableXPCEndpoint: @unchecked Sendable {
@@ -37,6 +39,7 @@ private struct SendableXPCEndpoint: @unchecked Sendable {
 
 public actor ContainersService {
     private static let macOSRuntimeName = "container-runtime-macos"
+    private static let bootRecoveryRetryDelay: Duration = .seconds(2)
     static let killedInitExitWaitTimeout: Duration = .seconds(5)
 
     enum StartProcessResult: Sendable {
@@ -121,7 +124,8 @@ public actor ContainersService {
         for dir in directories {
             do {
                 let (config, options) = try Self.getContainerConfiguration(at: dir)
-                if options?.autoRemove ?? false {
+                let isStatelessMacOS = Self.isStatelessMacOSSandbox(config)
+                if (options?.autoRemove ?? false) && !isStatelessMacOS {
                     log.info(
                         "reap auto-remove container",
                         metadata: [
@@ -153,7 +157,10 @@ public actor ContainersService {
                 let state = ContainerState(
                     snapshot: .init(
                         configuration: config,
-                        status: .stopped,
+                        status: isStatelessMacOS
+                            && (MacOSRuntimeCleanup.isPending(root: dir) || options?.autoRemove == true)
+                            ? .stopping
+                            : .stopped,
                         networks: [],
                         startedDate: nil
                     ),
@@ -166,9 +173,8 @@ public actor ContainersService {
                     )
                 }
             } catch {
-                try? FileManager.default.removeItem(at: dir)
                 log.warning(
-                    "failed to load container",
+                    "failed to load container; retaining bundle for recovery",
                     metadata: [
                         "path": "\(dir.path)",
                         "error": "\(error)",
@@ -487,6 +493,10 @@ public actor ContainersService {
 
             let path = self.containerRoot.appendingPathComponent(id)
             let (config, _) = try Self.getContainerConfiguration(at: path)
+            try Self.requireNoPendingStatelessMacOSCleanup(
+                root: path,
+                configuration: config
+            )
             if let task = state.bootstrapTask {
                 return (task, config, false)
             }
@@ -683,23 +693,50 @@ public actor ContainersService {
     public func inspectSandbox(id: String) async throws -> SandboxSnapshot {
         self.log.debug("\(#function)")
 
+        try await self.confirmMissingSandboxHasExited(id: id)
         let state = try self._getContainerState(id: id)
         try Self.requireMacOSGuestControl(configuration: state.snapshot.configuration)
+        let path = self.containerRoot.appendingPathComponent(id)
+        let cleanupPending =
+            Self.isStatelessMacOSSandbox(state.snapshot.configuration)
+            && MacOSRuntimeCleanup.isPending(root: path)
 
-        if let task = state.bootstrapTask ?? state.sandboxStartTask {
+        if !cleanupPending, let task = state.bootstrapTask ?? state.sandboxStartTask {
             let client = try await task.value
             return try await client.state()
         }
-        if let client = state.client {
+        if !cleanupPending, let client = state.client {
             return try await client.state()
         }
 
-        let path = self.containerRoot.appendingPathComponent(id)
-        let (configuration, _) = try Self.getContainerConfiguration(at: path)
+        let configuration = state.snapshot.configuration
+        var status = state.snapshot.status
+        if Self.isStatelessMacOSSandbox(configuration) {
+            if cleanupPending {
+                status = .stopping
+            } else {
+                do {
+                    try await self.confirmStatelessMacOSRuntimeStopped(
+                        id: id,
+                        configuration: configuration
+                    )
+                    status = .stopped
+                } catch {
+                    status = .stopping
+                    self.log.debug(
+                        "stateless macOS sandbox exit is not confirmed",
+                        metadata: [
+                            "id": "\(id)",
+                            "error": "\(error)",
+                        ]
+                    )
+                }
+            }
+        }
         return try Self.makePersistedSandboxSnapshot(
             root: path,
             configuration: configuration,
-            containerStatus: state.snapshot.status,
+            containerStatus: status,
             containerNetworks: state.snapshot.networks,
             startedDate: state.snapshot.startedDate
         )
@@ -714,6 +751,10 @@ public actor ContainersService {
 
         let state = try self._getContainerState(id: id)
         try Self.requireMacOSGuestControl(configuration: state.snapshot.configuration)
+        try Self.requireNoPendingStatelessMacOSCleanup(
+            root: self.containerRoot.appendingPathComponent(id),
+            configuration: state.snapshot.configuration
+        )
         let stagedContainerConfiguration =
             state.snapshot.status == .running
             ? nil
@@ -795,6 +836,10 @@ public actor ContainersService {
 
         let state = try self._getContainerState(id: id)
         try Self.requireMacOSGuestControl(configuration: state.snapshot.configuration)
+        try Self.requireNoPendingStatelessMacOSCleanup(
+            root: self.containerRoot.appendingPathComponent(id),
+            configuration: state.snapshot.configuration
+        )
         let client = try state.getClient()
         try await client.startWorkload(workloadID)
 
@@ -874,6 +919,15 @@ public actor ContainersService {
 
         let state = try self._getContainerState(id: id)
         try Self.requireMacOSGuestControl(configuration: state.snapshot.configuration)
+        let path = self.containerRoot.appendingPathComponent(id)
+        if Self.isStatelessMacOSSandbox(state.snapshot.configuration),
+            MacOSRuntimeCleanup.isPending(root: path)
+        {
+            throw ContainerizationError(
+                .invalidState,
+                message: "sandbox \(id) cleanup is pending"
+            )
+        }
 
         if let task = state.bootstrapTask ?? state.sandboxStartTask {
             let client = try await task.value
@@ -883,7 +937,12 @@ public actor ContainersService {
             return try await client.inspectWorkload(workloadID)
         }
 
-        let path = self.containerRoot.appendingPathComponent(id)
+        if Self.isStatelessMacOSSandbox(state.snapshot.configuration) {
+            try await self.confirmStatelessMacOSRuntimeStopped(
+                id: id,
+                configuration: state.snapshot.configuration
+            )
+        }
         let (configuration, _) = try Self.getContainerConfiguration(at: path)
         let sandboxSnapshot = try Self.makePersistedSandboxSnapshot(
             root: path,
@@ -1163,6 +1222,10 @@ public actor ContainersService {
             logMetadata: ["acquirer": "\(#function)", "id": "\(id)", "processId": "\(processID)"]
         ) { context -> StartWork in
             var state = try await self.getContainerState(id: id, context: context)
+            try Self.requireNoPendingStatelessMacOSCleanup(
+                root: self.containerRoot.appendingPathComponent(id),
+                configuration: state.snapshot.configuration
+            )
 
             let isInit = Self.isInitProcess(id: id, processID: processID)
             if state.snapshot.status == .running && isInit {
@@ -1200,6 +1263,18 @@ public actor ContainersService {
                     state.processStartTasks.removeValue(forKey: processID)
                     var shouldTrackExit = false
                     if case .initProcessStarted(let networks) = result {
+                        try Self.requireNoPendingStatelessMacOSCleanup(
+                            root: self.containerRoot.appendingPathComponent(id),
+                            configuration: state.snapshot.configuration
+                        )
+                        if Self.isStatelessMacOSSandbox(state.snapshot.configuration),
+                            state.client == nil
+                        {
+                            throw ContainerizationError(
+                                .invalidState,
+                                message: "sandbox cleanup completed while the init process was starting"
+                            )
+                        }
                         shouldTrackExit = state.snapshot.status != .running
                         state.snapshot.status = .running
                         state.snapshot.networks = networks
@@ -1345,26 +1420,67 @@ public actor ContainersService {
             )
         }
 
-        let state = try self._getContainerState(id: id)
+        try await self.confirmMissingSandboxHasExited(id: id)
+        let (client, isStatelessMacOS, resolvedOptions) = try await self.lock.withLock {
+            context -> (RuntimeClient?, Bool, ContainerStopOptions) in
+            var state = try await self.getContainerState(id: id, context: context)
+            let configuration = state.snapshot.configuration
+            let isStatelessMacOS = Self.isStatelessMacOSSandbox(configuration)
+            var resolvedOptions = options
+            if resolvedOptions.signal == nil {
+                resolvedOptions.signal = configuration.stopSignal
+            }
+            if let signal = resolvedOptions.signal {
+                _ = try Signal(signal, from: Signal.platform)
+            }
+            if isStatelessMacOS {
+                guard state.bootstrapTask == nil,
+                    state.sandboxStartTask == nil,
+                    state.processStartTasks.isEmpty
+                else {
+                    throw ContainerizationError(
+                        .invalidState,
+                        message: "sandbox start is in progress; retry stop after it completes"
+                    )
+                }
+                try MacOSRuntimeCleanup.markPending(
+                    root: self.containerRoot.appendingPathComponent(id)
+                )
+                state.snapshot.status = .stopping
+                await self.setContainerState(id, state, context: context)
+            }
+            return (state.client, isStatelessMacOS, resolvedOptions)
+        }
 
-        // Stop should be idempotent.
-        let client: RuntimeClient
-        do {
-            client = try state.getClient()
-        } catch {
+        guard client != nil || isStatelessMacOS else {
             return
         }
 
-        var resolvedOptions = options
-        if resolvedOptions.signal == nil, let stopSignal = state.snapshot.configuration.stopSignal {
-            resolvedOptions.signal = stopSignal
-        }
-
-        do {
-            try await client.stop(options: resolvedOptions)
-        } catch let err as ContainerizationError {
-            if err.code != .interrupted {
-                throw err
+        if let client {
+            do {
+                try await client.stop(options: resolvedOptions)
+            } catch let error as ContainerizationError {
+                if !isStatelessMacOS, error.code != .interrupted {
+                    throw error
+                }
+                self.log.warning(
+                    "runtime stop did not complete; continuing with verified macOS cleanup",
+                    metadata: [
+                        "id": "\(id)",
+                        "error": "\(error)",
+                    ]
+                )
+            } catch {
+                guard isStatelessMacOS else {
+                    throw error
+                }
+                self.log.warning(
+                    "runtime stop did not complete; continuing with verified macOS cleanup",
+                    metadata: [
+                        "id": "\(id)",
+                        "error": "\(error)",
+                    ]
+                )
             }
         }
         try await handleContainerExit(id: id)
@@ -1560,47 +1676,61 @@ public actor ContainersService {
             )
         }
 
+        try await self.confirmMissingSandboxHasExited(id: id)
         let state = try self._getContainerState(id: id)
+        let isStatelessMacOS = Self.isStatelessMacOSSandbox(state.snapshot.configuration)
         switch state.snapshot.status {
         case .running:
-            if !force {
+            guard force else {
                 throw ContainerizationError(
                     .invalidState,
                     message: "container \(id) is \(state.snapshot.status) and can not be deleted"
                 )
             }
-            let opts = ContainerStopOptions(
-                timeoutInSeconds: 5,
-                signal: "SIGKILL"
-            )
-            let client = try state.getClient()
-            try await client.stop(options: opts)
-            try await self.lock.withLock(logMetadata: ["acquirer": "\(#function)", "id": "\(id)"]) { context in
-                self.log.info(
-                    "ContainersService: attempt cleanup",
-                    metadata: [
-                        "func": "\(#function)",
-                        "id": "\(id)",
-                    ]
+            try await self.stop(
+                id: id,
+                options: ContainerStopOptions(
+                    timeoutInSeconds: 5,
+                    signal: "SIGKILL"
                 )
-                try await self.cleanUp(id: id, context: context)
-                self.log.info(
-                    "ContainersService: successful cleanup",
-                    metadata: [
-                        "func": "\(#function)",
-                        "id": "\(id)",
-                    ]
+            )
+        case .stopping:
+            guard force, isStatelessMacOS else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "container \(id) is \(state.snapshot.status) and can not be deleted"
                 )
             }
-        case .stopping:
-            throw ContainerizationError(
-                .invalidState,
-                message: "container \(id) is \(state.snapshot.status) and can not be deleted"
+            try await self.stop(
+                id: id,
+                options: ContainerStopOptions(
+                    timeoutInSeconds: 0,
+                    signal: "SIGKILL"
+                )
             )
         default:
-            try await self.lock.withLock(logMetadata: ["acquirer": "\(#function)", "id": "\(id)"]) { context in
-                try await self.cleanUp(id: id, context: context)
-            }
+            break
+        }
+
+        guard self.containers[id] != nil else {
+            return
+        }
+        try await self.lock.withLock(logMetadata: ["acquirer": "\(#function)", "id": "\(id)"]) { context in
+            self.log.info(
+                "ContainersService: attempt cleanup",
+                metadata: [
+                    "func": "\(#function)",
+                    "id": "\(id)",
+                ]
+            )
+            try await self.cleanUp(id: id, context: context)
+            self.log.info(
+                "ContainersService: successful cleanup",
+                metadata: [
+                    "func": "\(#function)",
+                    "id": "\(id)",
+                ]
+            )
         }
     }
 
@@ -1660,7 +1790,9 @@ public actor ContainersService {
         var state: ContainerState
         do {
             state = try self.getContainerState(id: id, context: context)
-            if state.snapshot.status == .stopped {
+            if state.snapshot.status == .stopped,
+                !Self.isStatelessMacOSSandbox(state.snapshot.configuration)
+            {
                 return
             }
         } catch {
@@ -1668,22 +1800,23 @@ public actor ContainersService {
             return
         }
 
-        await self.exitMonitor.stopTracking(id: id)
-
         // Shutdown and deregister the runtime service
         self.log.info("shutting down runtime service", metadata: ["id": "\(id)"])
 
         let path = self.containerRoot.appendingPathComponent(id)
-        let bundle = ContainerResource.Bundle(path: path)
-        let config = try bundle.configuration
+        let config = state.snapshot.configuration
+        let isStatelessMacOS = Self.isStatelessMacOSSandbox(config)
         let label = Self.fullLaunchdServiceLabel(
             runtimeName: config.runtimeHandler,
             instanceId: id
         )
 
-        // Try to shutdown the client gracefully, but if the runtime service
-        // is already dead (e.g., killed externally), we should still continue
-        // with state cleanup.
+        if isStatelessMacOS {
+            try MacOSRuntimeCleanup.markPending(root: path)
+            state.snapshot.status = .stopping
+            await self.setContainerState(id, state, context: context)
+        }
+
         if let client = state.client {
             do {
                 try await client.shutdown()
@@ -1697,21 +1830,30 @@ public actor ContainersService {
             }
         }
 
-        // Deregister the service, launchd will terminate the process.
-        // This may also fail if the service was already deregistered or
-        // the process was killed externally.
-        do {
-            try ServiceManager.deregister(fullServiceLabel: label)
-            self.log.info("deregistered runtime service", metadata: ["id": "\(id)"])
-        } catch {
-            self.log.error(
-                "failed to deregister runtime service",
-                metadata: [
-                    "id": "\(id)",
-                    "error": "\(error)",
-                ])
+        if isStatelessMacOS {
+            try await MacOSRuntimeCleanup.stop(
+                id: id,
+                root: path,
+                parentLabel: label,
+                sidecarLabel: Self.statelessMacOSSidecarLabel(id: id)
+            )
+            try MacOSRuntimeCleanup.clearPending(root: path)
+        } else {
+            do {
+                try ServiceManager.deregister(fullServiceLabel: label)
+                self.log.info("deregistered runtime service", metadata: ["id": "\(id)"])
+            } catch {
+                self.log.error(
+                    "failed to deregister runtime service",
+                    metadata: [
+                        "id": "\(id)",
+                        "error": "\(error)",
+                    ]
+                )
+            }
         }
 
+        await self.exitMonitor.stopTracking(id: id)
         state.snapshot.status = .stopped
         state.snapshot.networks = []
         state.client = nil
@@ -1734,11 +1876,19 @@ public actor ContainersService {
         configuration: ContainerConfiguration,
         existingClient: RuntimeClient?
     ) async throws -> RuntimeClient {
+        let path = self.containerRoot.appendingPathComponent(id)
+        if Self.isStatelessMacOSSandbox(configuration),
+            MacOSRuntimeCleanup.isPending(root: path)
+        {
+            throw ContainerizationError(
+                .invalidState,
+                message: "sandbox cleanup is pending; finish stop or delete before starting"
+            )
+        }
         if let existingClient {
             return existingClient
         }
 
-        let path = self.containerRoot.appendingPathComponent(id)
         guard let plugin = self.runtimePlugins.first(where: { $0.name == configuration.runtimeHandler }) else {
             throw ContainerizationError(
                 .notFound,
@@ -1785,6 +1935,32 @@ public actor ContainersService {
         configuration: ContainerConfiguration
     ) async {
         await self.exitMonitor.stopTracking(id: id)
+
+        if Self.isStatelessMacOSSandbox(configuration) {
+            let root = self.containerRoot.appendingPathComponent(id)
+            do {
+                try await MacOSRuntimeCleanup.stop(
+                    id: id,
+                    root: root,
+                    parentLabel: Self.fullLaunchdServiceLabel(
+                        runtimeName: configuration.runtimeHandler,
+                        instanceId: id
+                    ),
+                    sidecarLabel: Self.statelessMacOSSidecarLabel(id: id)
+                )
+                try MacOSGuestNetworkLeaseStore.remove(from: root)
+                try MacOSRuntimeCleanup.clearPending(root: root)
+            } catch {
+                self.log.error(
+                    "failed runtime cleanup retained for retry",
+                    metadata: [
+                        "id": "\(id)",
+                        "error": "\(error)",
+                    ]
+                )
+            }
+            return
+        }
 
         if configuration.runtimeHandler == Self.macOSRuntimeName,
             let client = try? await RuntimeClient.create(id: id, runtime: configuration.runtimeHandler)
@@ -1969,16 +2145,42 @@ public actor ContainersService {
             return
         }
 
-        // To be pedantic. This is only needed if something in the "launch
-        // the init process" lifecycle fails before actually fork+exec'ing
-        // the OCI runtime.
-        await self.exitMonitor.stopTracking(id: id)
         let path = self.containerRoot.appendingPathComponent(id)
         let bundle = ContainerResource.Bundle(path: path)
+        let configuration = state.snapshot.configuration
 
-        if state.snapshot.configuration.macosGuest?.machineState != nil {
+        if Self.isStatelessMacOSSandbox(configuration) {
+            guard state.bootstrapTask == nil,
+                state.sandboxStartTask == nil,
+                state.processStartTasks.isEmpty
+            else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "sandbox start is in progress; retry delete after it completes"
+                )
+            }
+            try await MacOSRuntimeCleanup.stop(
+                id: id,
+                root: path,
+                parentLabel: Self.fullLaunchdServiceLabel(
+                    runtimeName: configuration.runtimeHandler,
+                    instanceId: id
+                ),
+                sidecarLabel: Self.statelessMacOSSidecarLabel(id: id)
+            )
+            try bundle.delete()
+            await self.exitMonitor.stopTracking(id: id)
+            self.containers.removeValue(forKey: id)
+            return
+        }
+
+        // This is needed if the init process fails before the OCI runtime has
+        // started tracking it.
+        await self.exitMonitor.stopTracking(id: id)
+
+        if configuration.macosGuest?.machineState != nil {
             let label = Self.fullLaunchdServiceLabel(
-                runtimeName: state.snapshot.configuration.runtimeHandler,
+                runtimeName: configuration.runtimeHandler,
                 instanceId: id
             )
             try ServiceManager.deregister(fullServiceLabel: label)
@@ -2068,33 +2270,78 @@ public actor ContainersService {
     }
 
     private func recoverSandboxStatesAtBoot() async {
-        let containerIDs = Array(self.containers.keys).sorted()
-        guard !containerIDs.isEmpty else {
-            return
-        }
-
-        for id in containerIDs {
-            await self.recoverSandboxStateAtBoot(id: id)
+        await Self.retrySandboxRecoveriesAtBoot(
+            containerIDs: Array(self.containers.keys),
+            retryDelay: Self.bootRecoveryRetryDelay
+        ) { [weak self] id in
+            guard let self else {
+                return false
+            }
+            return await self.recoverSandboxStateAtBoot(id: id)
         }
     }
 
-    private func recoverSandboxStateAtBoot(id: String) async {
+    static func retrySandboxRecoveriesAtBoot(
+        containerIDs: [String],
+        retryDelay: Duration,
+        recover: @escaping @Sendable (String) async -> Bool
+    ) async {
+        var pendingIDs = containerIDs.sorted()
+        while !pendingIDs.isEmpty, !Task.isCancelled {
+            var retryIDs: [String] = []
+            for id in pendingIDs {
+                if await recover(id) {
+                    retryIDs.append(id)
+                }
+            }
+            guard !retryIDs.isEmpty else {
+                return
+            }
+            do {
+                try await Task.sleep(for: retryDelay)
+            } catch {
+                return
+            }
+            pendingIDs = retryIDs
+        }
+    }
+
+    private func recoverSandboxStateAtBoot(id: String) async -> Bool {
         let runtimeName: String
         let fullServiceLabel: String
+        let configuration: ContainerConfiguration
+        let isStatelessMacOS: Bool
+        var retryAfterFailure = false
 
         do {
             let state = try self._getContainerState(id: id)
             guard state.client == nil, state.bootstrapTask == nil else {
-                return
+                return false
             }
-            runtimeName = state.snapshot.configuration.runtimeHandler
+            configuration = state.snapshot.configuration
+            runtimeName = configuration.runtimeHandler
+            isStatelessMacOS = Self.isStatelessMacOSSandbox(configuration)
+            retryAfterFailure = isStatelessMacOS
             fullServiceLabel = Self.fullLaunchdServiceLabel(
                 runtimeName: runtimeName,
                 instanceId: id
             )
 
+            if isStatelessMacOS {
+                let root = self.containerRoot.appendingPathComponent(id)
+                let autoRemove = (try? self.getContainerCreationOptions(id: id).autoRemove) == true
+                if MacOSRuntimeCleanup.isPending(root: root) || autoRemove {
+                    try await self.handleContainerExit(id: id)
+                    return false
+                }
+                if try MacOSRuntimeCleanup().serviceHasExited(label: fullServiceLabel) {
+                    try await self.handleContainerExit(id: id)
+                    return false
+                }
+            }
+
             guard try ServiceManager.isRegistered(fullServiceLabel: fullServiceLabel) else {
-                return
+                return false
             }
         } catch {
             self.log.warning(
@@ -2104,7 +2351,7 @@ public actor ContainersService {
                     "error": "\(error)",
                 ]
             )
-            return
+            return retryAfterFailure
         }
 
         do {
@@ -2135,10 +2382,10 @@ public actor ContainersService {
             )
 
             do {
-                try await self.registerContainerExitCallback(id: id)
                 guard shouldTrackExit else {
-                    return
+                    return false
                 }
+                try await self.registerContainerExitCallback(id: id)
                 try await self.trackContainerExit(id: id, client: client)
             } catch {
                 self.log.warning(
@@ -2149,6 +2396,7 @@ public actor ContainersService {
                     ]
                 )
             }
+            return false
         } catch {
             self.log.warning(
                 "failed to recover sandbox state at boot",
@@ -2158,6 +2406,25 @@ public actor ContainersService {
                     "error": "\(error)",
                 ]
             )
+            guard isStatelessMacOS else {
+                return false
+            }
+            do {
+                guard try MacOSRuntimeCleanup().serviceHasExited(label: fullServiceLabel) else {
+                    return true
+                }
+                try await self.handleContainerExit(id: id)
+                return false
+            } catch {
+                self.log.error(
+                    "failed to clean up unrecoverable stateless macOS sandbox",
+                    metadata: [
+                        "id": "\(id)",
+                        "error": "\(error)",
+                    ]
+                )
+                return true
+            }
         }
     }
 
@@ -2176,7 +2443,98 @@ public actor ContainersService {
             log.info("container \(id) finished in exit monitor, exit code \(code)")
             return code
         }
-        try await self.exitMonitor.track(id: id, waitingOn: waitFunc)
+        let configuration = try self._getContainerState(id: id).snapshot.configuration
+        if configuration.runtimeHandler == Self.macOSRuntimeName {
+            try await self.exitMonitor.track(
+                id: id,
+                waitingOn: waitFunc,
+                onWaitFailure: { [weak self] id in
+                    try await self?.recoverAfterWaitFailure(id: id)
+                }
+            )
+        } else {
+            try await self.exitMonitor.track(id: id, waitingOn: waitFunc)
+        }
+    }
+
+    private func recoverAfterWaitFailure(id: String) async throws -> ExitStatus? {
+        let state = try self._getContainerState(id: id)
+        let configuration = state.snapshot.configuration
+        guard Self.isStatelessMacOSSandbox(configuration) else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "macOS machine-state cleanup requires lifecycle proof"
+            )
+        }
+        let parentLabel = Self.fullLaunchdServiceLabel(
+            runtimeName: configuration.runtimeHandler,
+            instanceId: id
+        )
+        guard try MacOSRuntimeCleanup().serviceHasExited(label: parentLabel) else {
+            return nil
+        }
+        return ExitStatus(exitCode: 255, exitedAt: Date())
+    }
+
+    private func confirmMissingSandboxHasExited(id: String) async throws {
+        guard self.containers[id] == nil else {
+            return
+        }
+        let root = self.containerRoot.appendingPathComponent(id)
+        try await MacOSRuntimeCleanup.confirmStopped(
+            id: id,
+            root: root,
+            parentLabel: Self.fullLaunchdServiceLabel(
+                runtimeName: Self.macOSRuntimeName,
+                instanceId: id
+            ),
+            sidecarLabel: Self.statelessMacOSSidecarLabel(id: id)
+        )
+    }
+
+    private func confirmStatelessMacOSRuntimeStopped(
+        id: String,
+        configuration: ContainerConfiguration
+    ) async throws {
+        try await MacOSRuntimeCleanup.confirmStopped(
+            id: id,
+            root: self.containerRoot.appendingPathComponent(id),
+            parentLabel: Self.fullLaunchdServiceLabel(
+                runtimeName: configuration.runtimeHandler,
+                instanceId: id
+            ),
+            sidecarLabel: Self.statelessMacOSSidecarLabel(id: id)
+        )
+    }
+
+    static func requireNoPendingStatelessMacOSCleanup(
+        root: URL,
+        configuration: ContainerConfiguration
+    ) throws {
+        guard
+            !Self.isStatelessMacOSSandbox(configuration)
+                || !MacOSRuntimeCleanup.isPending(root: root)
+        else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "sandbox cleanup is pending"
+            )
+        }
+    }
+
+    private static func isStatelessMacOSSandbox(
+        _ configuration: ContainerConfiguration
+    ) -> Bool {
+        configuration.runtimeHandler == Self.macOSRuntimeName
+            && configuration.macosGuest?.machineState == nil
+    }
+
+    private static func statelessMacOSSidecarLabel(id: String) -> String {
+        MacOSSidecarLaunchIdentity.fullLaunchLabel(
+            sandboxID: id,
+            persistenceID: nil,
+            effectiveUserID: UInt32(geteuid())
+        )
     }
 
     static func makeBootRecoveredState(

--- a/Sources/Services/Runtime/RuntimeClient/ExitMonitor.swift
+++ b/Sources/Services/Runtime/RuntimeClient/ExitMonitor.swift
@@ -25,6 +25,10 @@ public actor ExitMonitor {
     /// A callback that receives the client identifier and exit code.
     public typealias ExitCallback = @Sendable (String, ExitStatus) async throws -> Void
 
+    /// Recover from a failed wait and return a terminal status only when exit
+    /// can be established independently.
+    public typealias WaitFailureCallback = @Sendable (String) async throws -> ExitStatus?
+
     /// A function that waits for work to complete, returning an exit code.
     public typealias WaitHandler = @Sendable () async throws -> ExitStatus
 
@@ -71,7 +75,13 @@ public actor ExitMonitor {
     ///   - id: The client identifier for the work.
     ///   - waitingOn: A function that waits for the work to complete,
     ///     and then returns an exit code.
-    public func track(id: String, waitingOn: @escaping WaitHandler) async throws {
+    ///   - onWaitFailure: An optional recovery callback for runtimes that can
+    ///     independently establish whether the work is still running.
+    public func track(
+        id: String,
+        waitingOn: @escaping WaitHandler,
+        onWaitFailure: WaitFailureCallback? = nil
+    ) async throws {
         guard let onExit = self.exitCallbacks[id] else {
             throw ContainerizationError(.invalidState, message: "ExitMonitor not setup for process \(id)")
         }
@@ -79,12 +89,51 @@ public actor ExitMonitor {
             throw ContainerizationError(.invalidState, message: "already have a running task tracking process \(id)")
         }
         self.runningTasks[id] = Task {
-            do {
-                let exitStatus = try await waitingOn()
-                try await onExit(id, exitStatus)
-            } catch {
-                self.log?.error("WaitHandler for \(id) threw error \(String(describing: error))")
-                try? await onExit(id, ExitStatus(exitCode: -1))
+            while !Task.isCancelled {
+                let exitStatus: ExitStatus?
+                do {
+                    exitStatus = try await waitingOn()
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    self.log?.error("WaitHandler for \(id) threw error \(String(describing: error))")
+                    guard let onWaitFailure else {
+                        try? await onExit(id, ExitStatus(exitCode: -1))
+                        return
+                    }
+                    do {
+                        exitStatus = try await onWaitFailure(id)
+                    } catch {
+                        self.log?.error("Wait failure recovery for \(id) failed: \(error)")
+                        do {
+                            try await Task.sleep(for: .seconds(2))
+                        } catch {
+                            return
+                        }
+                        continue
+                    }
+                    guard exitStatus != nil else {
+                        do {
+                            try await Task.sleep(for: .seconds(2))
+                        } catch {
+                            return
+                        }
+                        continue
+                    }
+                }
+                guard !Task.isCancelled, let exitStatus else { return }
+                while !Task.isCancelled {
+                    do {
+                        try await onExit(id, exitStatus)
+                        return
+                    } catch {
+                        self.log?.error("Exit callback for \(id) failed: \(error)")
+                        do {
+                            try await Task.sleep(for: .seconds(2))
+                        } catch {
+                            return
+                        }
+                    }
+                }
             }
         }
     }

--- a/Sources/Services/Runtime/RuntimeClient/RuntimeClient.swift
+++ b/Sources/Services/Runtime/RuntimeClient/RuntimeClient.swift
@@ -223,7 +223,10 @@ extension RuntimeClient {
         let request = XPCMessage(route: RuntimeRoutes.state.rawValue)
         let response: XPCMessage
         do {
-            response = try await self.client.send(request)
+            response = try await self.client.send(
+                request,
+                responseTimeout: runtime == "container-runtime-macos" ? .seconds(10) : nil
+            )
         } catch {
             throw ContainerizationError(
                 .internalError,
@@ -471,10 +474,19 @@ extension RuntimeClient {
         request.set(key: RuntimeKeys.stopOptions.rawValue, value: data)
 
         do {
-            try await self.client.send(request)
+            try await self.client.send(
+                request,
+                responseTimeout: runtime == "container-runtime-macos"
+                    ? Self.stopSandboxResponseTimeout(options: options)
+                    : nil
+            )
         } catch {
             throw Self.mapStopError(error, id: self.id)
         }
+    }
+
+    static func stopSandboxResponseTimeout(options: ContainerStopOptions) -> Duration {
+        .seconds(max(Int64(options.timeoutInSeconds), 0) + 30)
     }
 
     static func mapStopError(_ error: any Error, id: String) -> ContainerizationError {
@@ -608,7 +620,10 @@ extension RuntimeClient {
         let request = XPCMessage(route: RuntimeRoutes.shutdown.rawValue)
 
         do {
-            _ = try await self.client.send(request)
+            _ = try await self.client.send(
+                request,
+                responseTimeout: runtime == "container-runtime-macos" ? .seconds(10) : nil
+            )
         } catch {
             throw ContainerizationError(
                 .internalError,

--- a/Tests/ContainerAPIClientTests/ExecSyncTests.swift
+++ b/Tests/ContainerAPIClientTests/ExecSyncTests.swift
@@ -42,7 +42,7 @@ struct ExecSyncTests {
             return ScriptedProcess(
                 id: "exec-sync-capture",
                 onStart: {
-                    DispatchQueue.global().async {
+                    Thread.detachNewThread {
                         do {
                             defer {
                                 try? processStdin.close()

--- a/Tests/ContainerAPIClientTests/ParserTest.swift
+++ b/Tests/ContainerAPIClientTests/ParserTest.swift
@@ -809,7 +809,7 @@ struct ParserTest {
         let writerError = LockedValue<Error?>(nil)
 
         group.enter()
-        DispatchQueue.global(qos: .userInitiated).async {
+        Thread.detachNewThread {
             do {
                 let handle = try FileHandle(forWritingTo: pipePath)
                 try handle.write(contentsOf: "SECRET_KEY=value123\n".data(using: .utf8)!)

--- a/Tests/ContainerAPIServiceTests/ContainersServiceBootRecoveryTests.swift
+++ b/Tests/ContainerAPIServiceTests/ContainersServiceBootRecoveryTests.swift
@@ -14,9 +14,11 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import ContainerPlugin
 import ContainerXPC
 import ContainerizationExtras
 import Foundation
+import Logging
 import Testing
 
 @testable import ContainerAPIService
@@ -24,6 +26,96 @@ import Testing
 @testable import ContainerRuntimeClient
 
 struct ContainersServiceBootRecoveryTests {
+    @Test
+    func pendingCleanupRejectsStatelessMacOSStartAdmission() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: false
+        )
+        var configuration = try makeContainerConfiguration(id: root.lastPathComponent)
+        configuration.runtimeHandler = "container-runtime-macos"
+        try MacOSRuntimeCleanup.markPending(root: root)
+
+        #expect(throws: (any Error).self) {
+            try ContainersService.requireNoPendingStatelessMacOSCleanup(
+                root: root,
+                configuration: configuration
+            )
+        }
+    }
+
+    @Test
+    func bootLoadRetainsPendingAutoRemoveAndUnreadableBundles() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let containers = root.appendingPathComponent("containers")
+        let path = containers.appendingPathComponent("boot-recovery")
+        try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+        var configuration = try makeContainerConfiguration(id: "boot-recovery")
+        configuration.runtimeHandler = "container-runtime-macos"
+        let bundle = ContainerResource.Bundle(path: path)
+        try bundle.write(filename: "config.json", value: configuration)
+        try bundle.write(
+            filename: "options.json",
+            value: ContainerCreateOptions(autoRemove: true)
+        )
+
+        let unreadable = containers.appendingPathComponent("unreadable")
+        try FileManager.default.createDirectory(
+            at: unreadable,
+            withIntermediateDirectories: false
+        )
+        try Data("retained VM disk".utf8).write(
+            to: unreadable.appendingPathComponent("Disk.img")
+        )
+
+        let loader = try PluginLoader(
+            appRoot: root,
+            installRoot: root,
+            logRoot: nil,
+            pluginDirectories: [],
+            pluginFactories: []
+        )
+        let states = try ContainersService.loadAtBoot(
+            root: containers,
+            loader: loader,
+            log: Logger(label: "boot-recovery-test")
+        )
+
+        #expect(states[configuration.id]?.snapshot.status == .stopping)
+        #expect(FileManager.default.fileExists(atPath: path.path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: unreadable.appendingPathComponent("Disk.img").path
+            )
+        )
+    }
+
+    @Test
+    func bootRecoveryRetriesOnlyPendingSandboxes() async {
+        let recorder = BootRecoveryAttemptRecorder(
+            failuresRemaining: [
+                "already-clean": 0,
+                "retry-once": 1,
+            ]
+        )
+
+        await ContainersService.retrySandboxRecoveriesAtBoot(
+            containerIDs: ["retry-once", "already-clean"],
+            retryDelay: .milliseconds(1)
+        ) { id in
+            await recorder.recover(id: id)
+        }
+
+        let completedAttempts = await recorder.attempts(for: "already-clean")
+        let retriedAttempts = await recorder.attempts(for: "retry-once")
+        #expect(completedAttempts == 1)
+        #expect(retriedAttempts == 2)
+    }
+
     @Test
     func bootRecoveryKeepsRecoveredClientForStoppedSandbox() throws {
         let existing = try makeContainerState(status: .stopped, networks: [], startedDate: Date())
@@ -226,5 +318,27 @@ struct ContainersServiceBootRecoveryTests {
             runtime: "container-runtime-macos",
             client: XPCClient(service: "com.apple.container.tests.boot-recovery")
         )
+    }
+}
+
+private actor BootRecoveryAttemptRecorder {
+    private var attemptsByID: [String: Int] = [:]
+    private var failuresRemaining: [String: Int]
+
+    init(failuresRemaining: [String: Int]) {
+        self.failuresRemaining = failuresRemaining
+    }
+
+    func recover(id: String) -> Bool {
+        attemptsByID[id, default: 0] += 1
+        guard let remaining = failuresRemaining[id], remaining > 0 else {
+            return false
+        }
+        failuresRemaining[id] = remaining - 1
+        return true
+    }
+
+    func attempts(for id: String) -> Int {
+        attemptsByID[id, default: 0]
     }
 }

--- a/Tests/ContainerAPIServiceTests/ExitMonitorTests.swift
+++ b/Tests/ContainerAPIServiceTests/ExitMonitorTests.swift
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Containerization
+import ContainerizationError
+import Foundation
+import Testing
+
+@testable import ContainerRuntimeClient
+
+struct ExitMonitorTests {
+    actor Recorder {
+        var waits = 0
+        var exits: [Int32] = []
+        var failures = 0
+
+        func wait() throws -> Containerization.ExitStatus {
+            waits += 1
+            if waits == 1 {
+                throw ContainerizationError(.interrupted, message: "XPC interrupted")
+            }
+            return Containerization.ExitStatus(exitCode: 17)
+        }
+
+        func failWait() throws -> Containerization.ExitStatus {
+            waits += 1
+            throw ContainerizationError(.interrupted, message: "XPC interrupted")
+        }
+
+        func exited(_ status: Containerization.ExitStatus) {
+            exits.append(status.exitCode)
+        }
+
+        func failed() {
+            failures += 1
+        }
+
+        func exitFailingOnce(_ status: Containerization.ExitStatus) throws {
+            exits.append(status.exitCode)
+            if exits.count == 1 {
+                throw ContainerizationError(.timeout, message: "cleanup failed")
+            }
+        }
+    }
+
+    @Test
+    func waitErrorIsRetriedWithoutInventingExit() async throws {
+        let recorder = Recorder()
+        let monitor = ExitMonitor()
+        try await monitor.registerProcess(
+            id: "sandbox",
+            onExit: { _, status in await recorder.exited(status) }
+        )
+        try await monitor.track(
+            id: "sandbox",
+            waitingOn: { try await recorder.wait() },
+            onWaitFailure: { _ in
+                await recorder.failed()
+                return nil
+            }
+        )
+        for _ in 0..<100 {
+            if await recorder.exits == [17] { break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(await recorder.exits == [17])
+        #expect(await recorder.failures == 1)
+        await monitor.stopTracking(id: "sandbox")
+    }
+
+    @Test
+    func waitErrorWithoutRecoveryPreservesTerminalFallback() async throws {
+        let recorder = Recorder()
+        let monitor = ExitMonitor()
+        try await monitor.registerProcess(
+            id: "sandbox",
+            onExit: { _, status in await recorder.exited(status) }
+        )
+        try await monitor.track(
+            id: "sandbox",
+            waitingOn: { try await recorder.failWait() }
+        )
+        for _ in 0..<20 {
+            if await recorder.exits == [-1] { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await recorder.exits == [-1])
+        #expect(await recorder.waits == 1)
+        await monitor.stopTracking(id: "sandbox")
+    }
+
+    @Test
+    func waitRecoveryCanProvideAnIndependentlyConfirmedExit() async throws {
+        let recorder = Recorder()
+        let monitor = ExitMonitor()
+        try await monitor.registerProcess(
+            id: "sandbox",
+            onExit: { _, status in await recorder.exited(status) }
+        )
+        try await monitor.track(
+            id: "sandbox",
+            waitingOn: { try await recorder.failWait() },
+            onWaitFailure: { _ in
+                await recorder.failed()
+                return Containerization.ExitStatus(exitCode: 255)
+            }
+        )
+        for _ in 0..<20 {
+            if await recorder.exits == [255] { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await recorder.exits == [255])
+        #expect(await recorder.waits == 1)
+        #expect(await recorder.failures == 1)
+        await monitor.stopTracking(id: "sandbox")
+    }
+
+    @Test
+    func cleanupFailureRetriesTheConfirmedExitStatus() async throws {
+        let recorder = Recorder()
+        let monitor = ExitMonitor()
+        try await monitor.registerProcess(
+            id: "sandbox",
+            onExit: { _, status in try await recorder.exitFailingOnce(status) }
+        )
+        try await monitor.track(
+            id: "sandbox",
+            waitingOn: { Containerization.ExitStatus(exitCode: 17) }
+        )
+        for _ in 0..<100 {
+            if await recorder.exits.count == 2 { break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(await recorder.exits == [17, 17])
+        await monitor.stopTracking(id: "sandbox")
+    }
+
+    @Test
+    func cancellationDoesNotTriggerExitOrRecovery() async throws {
+        let recorder = Recorder()
+        let monitor = ExitMonitor()
+        try await monitor.registerProcess(
+            id: "sandbox",
+            onExit: { _, status in await recorder.exited(status) }
+        )
+        try await monitor.track(
+            id: "sandbox",
+            waitingOn: {
+                try await Task.sleep(for: .seconds(30))
+                return Containerization.ExitStatus(exitCode: 0)
+            },
+            onWaitFailure: { _ in
+                await recorder.failed()
+                return nil
+            }
+        )
+        await monitor.stopTracking(id: "sandbox")
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await recorder.exits.isEmpty)
+        #expect(await recorder.failures == 0)
+    }
+}

--- a/Tests/ContainerAPIServiceTests/RuntimeClientTests.swift
+++ b/Tests/ContainerAPIServiceTests/RuntimeClientTests.swift
@@ -25,6 +25,25 @@ import Testing
 
 struct RuntimeClientTests {
     @Test
+    func sandboxStopResponseTimeoutCoversGuestShutdown() {
+        #expect(
+            RuntimeClient.stopSandboxResponseTimeout(
+                options: ContainerStopOptions(timeoutInSeconds: 0, signal: nil)
+            ) == .seconds(30)
+        )
+        #expect(
+            RuntimeClient.stopSandboxResponseTimeout(
+                options: ContainerStopOptions(timeoutInSeconds: 30, signal: nil)
+            ) == .seconds(60)
+        )
+        #expect(
+            RuntimeClient.stopSandboxResponseTimeout(
+                options: ContainerStopOptions(timeoutInSeconds: .max, signal: nil)
+            ) == .seconds(2_147_483_677)
+        )
+    }
+
+    @Test
     func stopWorkloadResponseTimeoutCoversGracefulAndForcedWaits() {
         #expect(
             RuntimeClient.stopWorkloadResponseTimeout(

--- a/Tests/ContainerCRIShimMacOSTests/CRIShimCoreMappingTests.swift
+++ b/Tests/ContainerCRIShimMacOSTests/CRIShimCoreMappingTests.swift
@@ -20,8 +20,31 @@ import Testing
 
 @testable import ContainerCRI
 @testable import ContainerCRIShimMacOS
+@testable import ContainerResource
 
 struct CRIShimCoreMappingTests {
+    @Test
+    func stoppingSandboxIsReportedAsNotReady() {
+        let metadata = CRIShimSandboxMetadata(
+            id: "sandbox",
+            runtimeHandler: "macos",
+            sandboxImage: "example.com/macos/sandbox:latest",
+            state: .running,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+        let snapshot = SandboxSnapshot(
+            status: .stopping,
+            networks: [],
+            containers: []
+        )
+
+        let updated = metadata.applying(sandboxSnapshot: snapshot)
+
+        #expect(updated.state == .pending)
+        #expect(makeCRIPodSandbox(updated).state == .sandboxNotready)
+    }
+
     @Test
     func mapsSandboxRequestToMetadata() throws {
         var request = Runtime_V1_RunPodSandboxRequest()

--- a/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
+++ b/Tests/ContainerCRIShimMacOSTests/CRIShimRuntimeServerTests.swift
@@ -505,6 +505,13 @@ struct CRIShimRuntimeServerTests {
             workloadSnapshots: ["container-1": sandboxWorkloadSnapshot]
         )
         let cniManager = RecordingCNIManager()
+        cniManager.addHook = {
+            let metadata = try #require(
+                try metadataStore.listSandboxes().first(where: { $0.podUID == "created-pod-uid" })
+            )
+            #expect(metadata.state == .pending)
+            #expect(metadata.networkAttachments == ["default"])
+        }
         let server = try CRIShimGRPCServer(
             socketPath: socketPath,
             config: config,
@@ -830,7 +837,17 @@ struct CRIShimRuntimeServerTests {
 
         var removeSandboxRequest = Runtime_V1_RemovePodSandboxRequest()
         removeSandboxRequest.podSandboxID = runSandbox.podSandboxID
+        runtimeManager.removeSandboxError = ContainerizationError(
+            .timeout,
+            message: "sidecar cleanup is incomplete"
+        )
+        await #expect(throws: (any Error).self) {
+            _ = try await client.removePodSandbox(removeSandboxRequest)
+        }
+        #expect(try metadataStore.sandbox(id: runSandbox.podSandboxID) != nil)
+        runtimeManager.removeSandboxError = nil
         _ = try await client.removePodSandbox(removeSandboxRequest)
+        #expect(runtimeManager.stopSandboxCalls.count == 3)
         #expect(runtimeManager.removeSandboxCalls.count == 1)
         let removeSandboxCall = try #require(runtimeManager.removeSandboxCalls.first)
         #expect(removeSandboxCall.id == runSandbox.podSandboxID)
@@ -6372,6 +6389,7 @@ private final class RecordingRuntimeManager: CRIShimRuntimeManaging, @unchecked 
     var stopWorkloadExitCode: Int32 = 42
     var stopWorkloadExitedAt: Date?
     var removeWorkloadError: (any Error)?
+    var removeSandboxError: (any Error)?
     var inspectSandboxError: (any Error)?
     var inspectSandboxResults: [String: [SandboxSnapshot?]] = [:]
     var inspectWorkloadError: (any Error)?
@@ -6522,6 +6540,9 @@ private final class RecordingRuntimeManager: CRIShimRuntimeManaging, @unchecked 
         id: String,
         force: Bool
     ) async throws {
+        if let removeSandboxError {
+            throw removeSandboxError
+        }
         sandboxSnapshots.removeValue(forKey: id)
         removeSandboxCalls.append((id: id, force: force))
     }
@@ -6892,6 +6913,7 @@ private final class RecordingRuntimeManager: CRIShimRuntimeManaging, @unchecked 
 private final class RecordingCNIManager: CRIShimCNIManaging, @unchecked Sendable {
     private(set) var addCalls: [(sandboxID: String, networkName: String)] = []
     private(set) var deleteCalls: [(sandboxID: String, networkName: String)] = []
+    var addHook: (() throws -> Void)?
 
     func add(
         sandboxID: String,
@@ -6899,6 +6921,7 @@ private final class RecordingCNIManager: CRIShimCNIManaging, @unchecked Sendable
         config: CRIShimConfig
     ) async throws -> CRIShimCNIResult {
         addCalls.append((sandboxID: sandboxID, networkName: networkName))
+        try addHook?()
         return CRIShimCNIResult(
             networkName: networkName,
             interfaceName: "eth0",

--- a/Tests/ContainerCRIShimMacOSTests/FileHandleByteWriterTests.swift
+++ b/Tests/ContainerCRIShimMacOSTests/FileHandleByteWriterTests.swift
@@ -25,7 +25,7 @@ import Glibc
 import Darwin
 #endif
 
-@Suite
+@Suite(.serialized)
 struct FileHandleByteWriterTests {
     @Test
     func partialWritesPreserveBytesAndOrder() async throws {

--- a/Tests/ContainerK8sFlannelVXLANMacOSTests/FlannelDaemonLifecycleTests.swift
+++ b/Tests/ContainerK8sFlannelVXLANMacOSTests/FlannelDaemonLifecycleTests.swift
@@ -451,7 +451,7 @@ private func runControlClient<T: Sendable>(
     _ operation: @escaping @Sendable () throws -> T
 ) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in
-        DispatchQueue.global(qos: .userInitiated).async {
+        Thread.detachNewThread {
             continuation.resume(with: Result(catching: operation))
         }
     }

--- a/Tests/ContainerK8sFlannelVXLANMacOSTests/FlannelForwardingTests.swift
+++ b/Tests/ContainerK8sFlannelVXLANMacOSTests/FlannelForwardingTests.swift
@@ -665,7 +665,7 @@ private final class ForwardingReadGate: @unchecked Sendable {
 
     func waitUntilBlocked() async -> Bool {
         await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async { [entered] in
+            Thread.detachNewThread { [entered] in
                 continuation.resume(returning: entered.wait(timeout: .now() + 10) == .success)
             }
         }
@@ -680,7 +680,7 @@ private func runForwardingOperation<T: Sendable>(
     _ operation: @escaping @Sendable () throws -> T
 ) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in
-        DispatchQueue.global(qos: .userInitiated).async {
+        Thread.detachNewThread {
             continuation.resume(with: Result(catching: operation))
         }
     }

--- a/Tests/ContainerPluginTests/MacOSRuntimeCleanupTests.swift
+++ b/Tests/ContainerPluginTests/MacOSRuntimeCleanupTests.swift
@@ -1,0 +1,262 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerizationError
+import Foundation
+import Testing
+
+@testable import ContainerPlugin
+
+struct MacOSRuntimeCleanupTests {
+    private func root() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        return root
+    }
+
+    @Test
+    func nativeInspectionDetectsAnUnlinkedVMFileHeldByATestProcess() throws {
+        let root = try root()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("AuxiliaryStorage")
+        try Data().write(to: file)
+        let output = try FileHandle(forWritingTo: file)
+        let child = Process()
+        child.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        child.arguments = ["30"]
+        child.standardOutput = output
+        try child.run()
+        defer {
+            if child.isRunning {
+                child.terminate()
+                child.waitUntilExit()
+            }
+        }
+        try output.close()
+        try FileManager.default.removeItem(at: file)
+        let cleanup = MacOSRuntimeCleanup()
+        #expect(throws: (any Error).self) {
+            try cleanup.confirmStopped(
+                id: root.lastPathComponent,
+                root: root,
+                parentLabel: "gui/501/parent",
+                sidecarLabel: "gui/501/sidecar"
+            )
+        }
+        child.terminate()
+        child.waitUntilExit()
+        try cleanup.confirmStopped(
+            id: root.lastPathComponent,
+            root: root,
+            parentLabel: "gui/501/parent",
+            sidecarLabel: "gui/501/sidecar"
+        )
+        #expect(!MacOSRuntimeCleanup.isPending(root: root))
+    }
+
+    @Test
+    func missingHandleReclaimsTheExactSuppliedSidecarAndWaitsForVM() throws {
+        let root = try root()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let label = "gui/501/com.example.sidecar.persistence-id"
+        var registered = true
+        var scans = 0
+        var bootouts: [String] = []
+        var cleanup = MacOSRuntimeCleanup()
+        cleanup.sleep = {}
+        cleanup.processExists = { _ in false }
+        cleanup.run = { executable, args in
+            if executable.hasSuffix("lsof") {
+                scans += 1
+                return .init(
+                    status: 0,
+                    output:
+                        scans == 1
+                        ? "p42\nn\(root.path)/Disk.img\n"
+                        : "p43\nn/other/normal/Disk.img\n"
+                )
+            }
+            #expect(args.last == label)
+            if args[0] == "bootout" {
+                #expect(MacOSRuntimeCleanup.isPending(root: root))
+                bootouts.append(args[1])
+                registered = false
+                return .init(status: 0, output: "")
+            }
+            return registered
+                ? .init(status: 0, output: "pid = 42\n")
+                : .init(
+                    status: 113,
+                    output: "",
+                    error: "Could not find service"
+                )
+        }
+        try cleanup.stop(
+            id: root.lastPathComponent,
+            root: root,
+            sidecarLabel: label
+        )
+        try cleanup.stop(
+            id: root.lastPathComponent,
+            root: root,
+            sidecarLabel: label
+        )
+        #expect(bootouts == [label])
+        #expect(scans == 3)
+    }
+
+    @Test
+    func bootoutFailureRetainsRetryRecord() throws {
+        let root = try root()
+        defer { try? FileManager.default.removeItem(at: root) }
+        var cleanup = MacOSRuntimeCleanup()
+        cleanup.attempts = 2
+        cleanup.sleep = {}
+        cleanup.run = { _, args in
+            args[0] == "print"
+                ? .init(status: 0, output: "pid = 42")
+                : .init(status: 5, output: "", error: "Input/output error")
+        }
+        #expect(throws: (any Error).self) {
+            try cleanup.stop(
+                id: root.lastPathComponent,
+                root: root,
+                sidecarLabel: "gui/501/sidecar"
+            )
+        }
+        #expect(MacOSRuntimeCleanup.isPending(root: root))
+    }
+
+    @Test
+    func absentLaunchdJobDoesNotProveVMExit() throws {
+        let root = try root()
+        defer { try? FileManager.default.removeItem(at: root) }
+        var cleanup = MacOSRuntimeCleanup()
+        cleanup.attempts = 2
+        cleanup.sleep = {}
+        cleanup.run = { executable, _ in
+            executable.hasSuffix("lsof")
+                ? .init(
+                    status: 0,
+                    output: "p42\nn\(root.path)/AuxiliaryStorage (deleted)\n"
+                )
+                : .init(
+                    status: 113,
+                    output: "",
+                    error: "Could not find service"
+                )
+        }
+        #expect(throws: (any Error).self) {
+            try cleanup.stop(
+                id: root.lastPathComponent,
+                root: root,
+                sidecarLabel: "gui/501/sidecar"
+            )
+        }
+        #expect(MacOSRuntimeCleanup.isPending(root: root))
+    }
+
+    @Test(arguments: [true, false])
+    func parentLivenessRequiresActualProcessExit(running: Bool) throws {
+        var cleanup = MacOSRuntimeCleanup()
+        cleanup.run = { _, _ in .init(status: 0, output: "pid = 42") }
+        cleanup.processExists = { _ in running }
+        #expect(
+            try cleanup.serviceHasExited(label: "gui/501/parent") == !running
+        )
+    }
+
+    @Test
+    func inspectionFailureNeverMeansAbsent() throws {
+        var cleanup = MacOSRuntimeCleanup()
+        cleanup.run = {
+            _, _ in
+            .init(status: 1, output: "", error: "Operation not permitted")
+        }
+        #expect(throws: (any Error).self) {
+            try cleanup.serviceHasExited(label: "gui/501/example")
+        }
+    }
+
+    @Test
+    func concurrentBootoutIsIdempotentAfterConfirmedExit() throws {
+        let root = try root()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let parent = "gui/501/parent"
+        let sidecar = "gui/501/sidecar"
+        var labels: [String] = []
+        var removed: Set<String> = []
+        var cleanup = MacOSRuntimeCleanup()
+        cleanup.sleep = {}
+        cleanup.processExists = { _ in false }
+        cleanup.run = { executable, args in
+            if executable.hasSuffix("lsof") {
+                return .init(status: 0, output: "")
+            }
+            let label = args[1]
+            if args[0] == "bootout" {
+                labels.append(label)
+                removed.insert(label)
+                return .init(status: 3, output: "", error: "No such process")
+            }
+            return removed.contains(label)
+                ? .init(
+                    status: 113,
+                    output: "",
+                    error: "Could not find service"
+                )
+                : .init(status: 0, output: "pid = 42")
+        }
+        try cleanup.stop(
+            id: root.lastPathComponent,
+            root: root,
+            parentLabel: parent,
+            sidecarLabel: sidecar
+        )
+        #expect(labels == [parent, sidecar])
+    }
+
+    @Test
+    func processMustExitEvenAfterJobDisappears() throws {
+        let root = try root()
+        defer { try? FileManager.default.removeItem(at: root) }
+        var removed = false
+        var cleanup = MacOSRuntimeCleanup()
+        cleanup.attempts = 2
+        cleanup.sleep = {}
+        cleanup.processExists = { _ in true }
+        cleanup.run = { _, args in
+            if args[0] == "bootout" {
+                removed = true
+                return .init(status: 0, output: "")
+            }
+            return removed
+                ? .init(
+                    status: 113,
+                    output: "",
+                    error: "Could not find service"
+                )
+                : .init(status: 0, output: "pid = 42")
+        }
+        #expect(throws: (any Error).self) {
+            try cleanup.stop(
+                id: root.lastPathComponent,
+                root: root,
+                sidecarLabel: "gui/501/sidecar"
+            )
+        }
+    }
+}

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSImageBackedWorkloadTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSImageBackedWorkloadTests.swift
@@ -624,13 +624,13 @@ struct MacOSImageBackedWorkloadTests {
 
         server.start()
 
+        let containerConfiguration = try Self.baseContainerConfiguration(indexDigest: image.indexDigest)
         let service = MacOSSandboxService(
-            root: tempDirectory.appendingPathComponent("sandbox"),
+            root: tempDirectory.appendingPathComponent(containerConfiguration.id),
             connection: nil,
             log: Logger(label: "MacOSImageBackedWorkloadTests"),
             contentStore: image.store
         )
-        let containerConfiguration = try Self.baseContainerConfiguration(indexDigest: image.indexDigest)
         try await service.testingPrepareSandbox(containerConfiguration, state: "running")
         await service.testingInstallSidecarClient(socketPath: socketPath)
 
@@ -690,13 +690,13 @@ struct MacOSImageBackedWorkloadTests {
 
         server.start()
 
+        let containerConfiguration = try Self.baseContainerConfiguration(indexDigest: image.indexDigest)
         let service = MacOSSandboxService(
-            root: tempDirectory.appendingPathComponent("sandbox"),
+            root: tempDirectory.appendingPathComponent(containerConfiguration.id),
             connection: nil,
             log: Logger(label: "MacOSImageBackedWorkloadTests"),
             contentStore: image.store
         )
-        let containerConfiguration = try Self.baseContainerConfiguration(indexDigest: image.indexDigest)
         try await service.testingPrepareSandbox(containerConfiguration, state: "running")
         await service.testingInstallSidecarClient(socketPath: socketPath)
 
@@ -917,13 +917,13 @@ struct MacOSImageBackedWorkloadTests {
 
         server.start()
 
+        let containerConfiguration = try Self.baseContainerConfiguration(indexDigest: image.indexDigest)
         let service = MacOSSandboxService(
-            root: tempDirectory.appendingPathComponent("sandbox"),
+            root: tempDirectory.appendingPathComponent(containerConfiguration.id),
             connection: nil,
             log: Logger(label: "MacOSImageBackedWorkloadTests"),
             contentStore: image.store
         )
-        let containerConfiguration = try Self.baseContainerConfiguration(indexDigest: image.indexDigest)
         try await service.testingPrepareSandbox(containerConfiguration, state: "running")
         await service.testingInstallSidecarClient(socketPath: socketPath)
 

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceNetworkTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceNetworkTests.swift
@@ -37,7 +37,10 @@ struct MacOSSandboxServiceNetworkTests {
 
         let recorder = RecordingSandboxNetworkControl()
         let service = makeService(root: root, recorder: recorder)
-        let config = try makeConfiguration(vmnetDisconnectRecovery: .stopSandbox)
+        let config = try makeConfiguration(
+            id: root.lastPathComponent,
+            vmnetDisconnectRecovery: .stopSandbox
+        )
         try await service.testingPrepareSandbox(config, state: initialState)
 
         await service.handleSandboxNetworkInvalidation(
@@ -92,6 +95,7 @@ struct MacOSSandboxServiceNetworkTests {
         let recorder = RecordingSandboxNetworkControl()
         let service = makeService(root: root, recorder: recorder)
         let config = try makeConfiguration(
+            id: root.lastPathComponent,
             vmnetDisconnectRecovery: .rebootNode,
             vmnetRecoveryStatePath: recoveryStatePath,
             vmnetRecoveryRequestPath: recoveryRequestPath,
@@ -763,6 +767,7 @@ private func makeService(root: URL, recorder: RecordingSandboxNetworkControl) ->
 }
 
 private func makeConfiguration(
+    id: String = "sandbox-network-test",
     backend: ContainerConfiguration.MacOSGuestOptions.NetworkBackend = .vmnetShared,
     vmnetDisconnectRecovery: ContainerConfiguration.MacOSGuestOptions.VMNetDisconnectRecovery = .disabled,
     vmnetRecoveryStatePath: String? = nil,
@@ -787,7 +792,7 @@ private func makeConfiguration(
     )
 
     var config = ContainerConfiguration(
-        id: "sandbox-network-test",
+        id: id,
         image: image,
         process: process
     )

--- a/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceWaiterTests.swift
+++ b/Tests/RuntimeMacOSSidecarClientTests/MacOSSandboxServiceWaiterTests.swift
@@ -117,7 +117,7 @@ struct MacOSSandboxServiceWaiterTests {
     }
 
     @Test
-    func unexpectedSidecarDisconnectResumesOutstandingWaiters() async throws {
+    func unexpectedSidecarDisconnectDoesNotReportWorkloadExit() async throws {
         let tempRoot = makeTemporaryRoot()
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
@@ -144,13 +144,28 @@ struct MacOSSandboxServiceWaiterTests {
         server.stop()
         try server.waitForCompletion()
 
-        let status = try await waitTask.value
-        #expect(status.exitCode == 255)
-        #expect(await service.testingWaiterCount(for: "exec-disconnect") == 0)
-
+        await service.handleUnexpectedSidecarDisconnect(
+            ContainerizationError(.interrupted, message: "test disconnect")
+        )
+        #expect(await service.testingWaiterCount(for: "exec-disconnect") == 1)
         let snapshot = try await service.testingInspectWorkload("exec-disconnect")
-        #expect(snapshot.status == .stopped)
-        #expect(snapshot.exitCode == 255)
+        #expect(snapshot.status == .running)
+        #expect(snapshot.exitCode == nil)
+
+        let replacement = try RecordingExecSidecarServer(socketPath: socketPath)
+        replacement.start()
+        defer { replacement.stop() }
+        try await service.testingSignalWorkload("exec-disconnect", signal: SIGUSR1)
+        #expect(
+            replacement.recordedRequests().contains {
+                $0.method == .processSignal
+            }
+        )
+
+        waitTask.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await waitTask.value
+        }
     }
 
     @Test
@@ -801,10 +816,14 @@ struct MacOSSandboxServiceWaiterTests {
 
     @Test
     func sidecarTeardownDrainsLateExitEventBeforeClosingSessions() async throws {
-        let tempRoot = makeTemporaryRoot()
-        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let temporaryDirectory = URL(
+            fileURLWithPath: "/tmp/macos-sidecar-\(UUID().uuidString.prefix(8))",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
 
         let configuration = try baseContainerConfiguration()
+        let tempRoot = temporaryDirectory.appendingPathComponent(configuration.id)
         let workloadID = configuration.id
         let sessionID = "__workload__pump-late-exit"
         let service = makeSandboxService(root: tempRoot)

--- a/Tests/RuntimeMacOSSidecarSharedTests/SidecarControlProtocolTests.swift
+++ b/Tests/RuntimeMacOSSidecarSharedTests/SidecarControlProtocolTests.swift
@@ -53,7 +53,7 @@ struct SidecarControlProtocolTests {
         #expect(decoded.protocolVersion == 3)
         #expect(decoded.eventAcknowledgement == acknowledgement)
         #expect(MacOSSidecarMethod(rawValue: "events.acknowledge") == .eventsAcknowledge)
-        #expect(MacOSSidecarProtocolVersion.supported == [1, 2, 3, 4, 5])
+        #expect(MacOSSidecarProtocolVersion.supported == [1, 2, 3, 4, 5, 6])
     }
 
     @Test

--- a/Tests/RuntimeMacOSSidecarTests/MachineStateSupportTests.swift
+++ b/Tests/RuntimeMacOSSidecarTests/MachineStateSupportTests.swift
@@ -421,9 +421,11 @@ struct MachineStateSupportTests {
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
         let socketURL = URL(fileURLWithPath: "/tmp/container-ms-wait-\(UUID().uuidString.prefix(8)).sock")
+        let publisherThreadStarted = DispatchSemaphore(value: 0)
         let listenerStarted = DispatchSemaphore(value: 0)
         let listenerFinished = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
+        Thread.detachNewThread {
+            publisherThreadStarted.signal()
             Thread.sleep(forTimeInterval: 0.05)
             guard let listener = try? UnixSocketListener(path: socketURL.path, expectedConnections: 1) else {
                 listenerFinished.signal()
@@ -434,6 +436,7 @@ struct MachineStateSupportTests {
             listener.close()
             listenerFinished.signal()
         }
+        #expect(publisherThreadStarted.wait(timeout: .now() + 2) == .success)
 
         let options = ContainerConfiguration.MacOSGuestOptions(
             snapshotEnabled: false,


### PR DESCRIPTION
## Summary

- keep stateless macOS sandbox cleanup pending until launchd jobs, recorded processes, and VM file handles are independently confirmed gone
- recover from runtime/XPC interruption without treating transport loss as VM exit, with durable boot retry and start/cleanup fencing
- preserve CRI/CNI cleanup identity and retain the existing machine-state lease and lifecycle proof model
- update the sidecar protocol test to include the existing version 6 capability

## Validation

- `make fmt`
- `make check`
- 131 focused cleanup, exit-monitor, boot-recovery, sidecar, and mapping tests passed
- 79 isolated CRI gRPC tests passed
- 6 isolated guest-agent process tests passed
- 1870 remaining Swift tests passed locally; the macOS 26 workflow will run the full suite, including the host-version-gated networking test
- staged and committed diffs passed whitespace and sensitive-information checks
- both commits are signed